### PR TITLE
Only issue warning when provisioning.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 #    puts("INFO: Using host directory #{ENV['GALAXY_DATABASE_DIR']} to exchange data with Galaxy.")
     config.vm.synced_folder ENV['GALAXY_DATABASE_DIR'], ENV['GALAXY_DATABASE_DIR']
   else
-#   puts("WARNING: $GALAXY_DATABASE_DIR is not set: copying files from local Galaxy instance will not work.")
+    config.vm.provision :shell, :inline =>
+<<GALAXY_WARNING_SCRIPT
+    echo 1>&2 'WARNING: $GALAXY_DATABASE_DIR is not set: copying files from local Galaxy instance will not work.'
+GALAXY_WARNING_SCRIPT
   end
 
   # If you'd like to be able to copy data from your host into the VM, set


### PR DESCRIPTION
There is a warning about `GALAXY_DATABASE_DIR` not being set, but it is commented out. I think it's useful. The naive way of including it means that you get the warning for innocuous commands like `vagrant --help`, but adding the warning as a provision script means that you only get it when you provision.

It looks like this for a `vagrant up`

![screenshot from 2015-09-03 13 48 48](https://cloud.githubusercontent.com/assets/1215412/9658639/d1c26a4e-5242-11e5-8869-a9dcef2c668d.png)

But as you see, `vagrant --help` is not affected:

![screenshot from 2015-09-03 13 53 19](https://cloud.githubusercontent.com/assets/1215412/9658707/4095a396-5243-11e5-8a23-05fab80d6719.png)
