### PR TITLE
Deploy on Amazon AWS

### DIFF
--- a/deployment/AWS.md
+++ b/deployment/AWS.md
@@ -1,5 +1,7 @@
 # Deployment on Amazon AWS
 
+## Summary
+
 Generate AWS Cloud Formation template file using `cfn-pyplates`
 and create stack using AWS cli tools.
 `awscli` and `cfn-pyplates` should already be

--- a/deployment/AWS.md
+++ b/deployment/AWS.md
@@ -1,0 +1,29 @@
+# Deployment on Amazon AWS
+
+Generate AWS Cloud Formation template file using `cfn-pyplates`
+and create stack using AWS cli tools.
+`awscli` and `cfn-pyplates` should already be
+in `requirements.txt`
+so you should already have installed all of that.
+
+## AWS account requirements
+
+- The AWS must have a key pair with KeyName `id_rsa`.
+- SSH access only works if the default security group allows
+  inbound access on port 22 (the SSH port).
+- HTTP access only works in the default security group allows
+  inbound access on port 80.
+
+## Generate JSON file and start stack:
+
+```
+cfn_py_generate aws-cfn.py deploy.json &&
+aws cloudformation create-stack --stack-name test-$(date +%Y%m%dT%H%M) --template-body file://deploy.json
+```
+
+This creates a stack with a new name every time, you might
+prefer to re-use the stack name and delete it when you want to
+create a new stack.
+
+
+

--- a/deployment/AWS.md
+++ b/deployment/AWS.md
@@ -17,7 +17,7 @@ so you should already have installed all of that.
 ## Generate JSON file and start stack:
 
 ```
-cfn_py_generate aws-cfn.py deploy.json &&
+cfn_py_generate aws_cfn.py deploy.json &&
 aws cloudformation create-stack --stack-name test-$(date +%Y%m%dT%H%M) --template-body file://deploy.json
 ```
 

--- a/deployment/AWS.md
+++ b/deployment/AWS.md
@@ -10,7 +10,7 @@ so you should already have installed all of that.
 
 ## AWS account requirements
 
-- The AWS must have a key pair with KeyName `id_rsa`.
+- The AWS account must have a key pair with KeyName `id_rsa`.
 - SSH access only works if the default security group allows
   inbound access on port 22 (the SSH port).
 - HTTP access only works in the default security group allows

--- a/deployment/apache.conf.erb
+++ b/deployment/apache.conf.erb
@@ -1,0 +1,35 @@
+WSGIPythonHome <%= @virtualenv %>
+WSGIScriptAlias / <%= @project_root %>/config/wsgi.py
+
+ServerName refinery.example.org
+
+<Directory <%= @project_root %>/config>
+    <Files wsgi.py>
+        Order deny,allow
+        Require all granted
+    </Files>
+</Directory>
+
+SetEnv DJANGO_SETTINGS_MODULE config.settings.dev
+
+WSGIDaemonProcess refinery user=<%= @appuser %> group=<%= @appgroup %> \
+    python-path=<%= @project_root %>:<%= @virtualenv %>/lib/python2.7/site-packages
+WSGIProcessGroup refinery
+
+#Alias /robots.txt /vagrant/refinery/static/robots.txt
+#Alias /favicon.ico /vagrant/refinery/static/favicon.ico
+
+AliasMatch ^/([^/]*\.css) <%= @project_root %>/static/styles/$1
+
+Alias /static/ <%= @source_root %>/static/
+Alias /media/ <%= @source_root %>/media/
+
+<Directory <%= @source_root %>/static>
+    Order deny,allow
+    Require all granted
+</Directory>
+
+<Directory <%= @source_root %>/media>
+    Order deny,allow
+    Require all granted
+</Directory>

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -7,13 +7,11 @@ set -x
 # to both Vagrant and AWS. Both bootstrap.sh and aws.sh (ths
 # script) are supplied via cloudinit userdata.
 
-OPERATIONS="htop"
-DEVELOPMENT="make puppet"
-/usr/bin/apt-get -q -y install $OPERATIONS $DEVELOPMENT 
+/usr/bin/apt-get -q -y install htop
 
 mkdir /srv/refinery-platform
 chown ubuntu:ubuntu /srv/refinery-platform
-sudo su -c 'git clone -b aws_vagrant https://github.com/drj11/refinery-platform.git /srv/refinery-platform' ubuntu
+sudo su -c 'git clone -b '"$GIT_BRANCH"' https://github.com/parklab/refinery-platform.git /srv/refinery-platform' ubuntu
 
 cd /srv/refinery-platform/deployment
 sudo su -c '/usr/local/bin/librarian-puppet install' ubuntu

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -4,7 +4,7 @@ set -x
 
 # This script is intened to be executed on AWS instance after
 # the bootstraph.sh script. The bootstrap.sh script is common
-# to both Vagrant and AWS. Both bootstrap.sh and aws.sh (ths
+# to both Vagrant and AWS. Both bootstrap.sh and aws.sh (this
 # script) are supplied via cloudinit userdata.
 
 /usr/bin/apt-get -q -y install htop

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -x
+
+# This script is intened to be executed on AWS instance after
+# the bootstraph.sh script. The bootstrap.sh script is common
+# to both Vagrant and AWS. Both bootstrap.sh and aws.sh (ths
+# script) are supplied via cloudinit userdata.
+
+OPERATIONS="htop"
+DEVELOPMENT="make puppet"
+/usr/bin/apt-get -q -y install $OPERATIONS $DEVELOPMENT 
+
+mkdir /srv/refinery-platform
+chown ubuntu:ubuntu /srv/refinery-platform
+sudo su -c 'git clone -b aws_vagrant https://github.com/drj11/refinery-platform.git /srv/refinery-platform' ubuntu
+
+cd /srv/refinery-platform/deployment
+sudo su -c '/usr/local/bin/librarian-puppet install' ubuntu
+
+/usr/bin/puppet apply --modulepath=/srv/refinery-platform/deployment/modules /srv/refinery-platform/deployment/manifests/aws.pp

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -7,6 +7,9 @@ set -x
 # to both Vagrant and AWS. Both bootstrap.sh and aws.sh (this
 # script) are supplied via cloudinit userdata.
 
+# Normally supplied as input, but use a default if not.
+GIT_BRANCH=${GIT_BRANCH:-develop}
+
 /usr/bin/apt-get -q -y install htop
 
 mkdir /srv/refinery-platform

--- a/deployment/aws_cfn.py
+++ b/deployment/aws_cfn.py
@@ -5,8 +5,13 @@
 # to deply to Amazon AWS.
 
 cft = CloudFormationTemplate(description="refinery monolithic template.")
+import os
+branch = os.popen("""git branch | awk '$1=="*"{print $2}'""").read()
+assert branch
 
-user_data_script = open('bootstrap.sh').read() + open('aws.sh').read()
+user_data_script = (open('bootstrap.sh').read() +
+  "GIT_BRANCH={}\n".format(branch) +
+  open('aws.sh').read())
 
 cft.resources.ec2_instance = Resource(
     'MonolithicInstance', 'AWS::EC2::Instance',

--- a/deployment/aws_cfn.py
+++ b/deployment/aws_cfn.py
@@ -1,0 +1,20 @@
+# This is a cfn-pyplates template file
+# for generating
+# an AWS CloudFormation json file.
+# See AWS.md for notes on how to use this
+# to deply to Amazon AWS.
+
+cft = CloudFormationTemplate(description="refinery monolithic template.")
+
+user_data_script = open('bootstrap.sh').read() + open('aws.sh').read()
+
+cft.resources.ec2_instance = Resource(
+    'MonolithicInstance', 'AWS::EC2::Instance',
+    Properties({
+        'ImageId': 'ami-d05e75b8',
+        'InstanceType': 'm3.medium',
+        'UserData': base64(user_data_script),
+        'KeyName': 'id_rsa',
+        'Tags': [{'Key': 'refinery', 'Value': 'refinery'}],
+    })
+)

--- a/deployment/aws_cfn.py
+++ b/deployment/aws_cfn.py
@@ -4,14 +4,16 @@
 # See AWS.md for notes on how to use this
 # to deply to Amazon AWS.
 
+import os       # for os.popen
+
 cft = CloudFormationTemplate(description="refinery monolithic template.")
-import os
 branch = os.popen("""git branch | awk '$1=="*"{print $2}'""").read()
 assert branch
 
-user_data_script = (open('bootstrap.sh').read() +
-  "GIT_BRANCH={}\n".format(branch) +
-  open('aws.sh').read())
+user_data_script = (
+    open('bootstrap.sh').read() +
+    "GIT_BRANCH={}\n".format(branch) +
+    open('aws.sh').read())
 
 cft.resources.ec2_instance = Resource(
     'MonolithicInstance', 'AWS::EC2::Instance',

--- a/deployment/bootstrap.sh
+++ b/deployment/bootstrap.sh
@@ -4,6 +4,8 @@ export DEBIAN_FRONTEND=noninteractive
 
 /usr/bin/apt-get clean && /usr/bin/apt-get -qq update
 
-/usr/bin/apt-get -q -y install git ruby-dev
+# "make" and "puppet" are required on AWS, and already installed
+# on Vagrant (so adding them again is quick).
+/usr/bin/apt-get -q -y install git ruby-dev make puppet
 
 /usr/bin/gem install librarian-puppet -v 2.2.1 --no-rdoc --no-ri && cd /vagrant/deployment && librarian-puppet install

--- a/deployment/manifests/aws.pp
+++ b/deployment/manifests/aws.pp
@@ -111,12 +111,10 @@ file_line { "django_settings_module":
   line => "export DJANGO_SETTINGS_MODULE=${django_settings_module}",
 }
 ->
-file { "${project_root}/config/config.json":
-  ensure => file,
-  source => "${project_root}/config/config.json.sample",
-  owner => $appuser,
+exec { "sed 's/\"vagrant\"/\"ubuntu\"/' '${project_root}/config/config.json.sample' > '${project_root}/config/config.json'":
+  creates => "${project_root}/config/config.json",
+  user => $appuser,
   group => $appgroup,
-  replace => false,
 }
 ->
 exec { "syncdb":
@@ -389,7 +387,7 @@ exec { 'apache2-wsgi':
 ->
 file { "/etc/apache2/sites-available/001-refinery.conf":
   ensure => file,
-  content => template("${source_root}/deployment/apache.conf"),
+  content => template("${source_root}/deployment/apache.conf.erb"),
 }
 ~>
 exec { 'refinery-apache2':

--- a/deployment/manifests/aws.pp
+++ b/deployment/manifests/aws.pp
@@ -111,7 +111,7 @@ file_line { "django_settings_module":
   line => "export DJANGO_SETTINGS_MODULE=${django_settings_module}",
 }
 ->
-exec { "sed 's/\"vagrant\"/\"ubuntu\"/' '${project_root}/config/config.json.sample' > '${project_root}/config/config.json'":
+exec { "/bin/sed 's/\"vagrant\"/\"ubuntu\"/' '${project_root}/config/config.json.sample' > '${project_root}/config/config.json'":
   creates => "${project_root}/config/config.json",
   user => $appuser,
   group => $appgroup,

--- a/deployment/manifests/aws.pp
+++ b/deployment/manifests/aws.pp
@@ -1,0 +1,407 @@
+$appuser = "ubuntu"
+$appgroup = "ubuntu"
+$virtualenv = "/home/${appuser}/.virtualenvs/refinery-platform"
+$source_root = "/srv/refinery-platform"
+$project_root = "${source_root}/refinery"
+$requirements = "${source_root}/requirements.txt"
+$django_settings_module = "config.settings.dev"
+$ui_app_root = "${project_root}/ui"
+
+# to make logs easier to read
+# class { 'timezone':
+#   timezone => 'America/New_York',
+# }
+
+# for better performance
+sysctl { 'vm.swappiness': value => '10' }
+
+# to avoid empty ident name not allowed error when using git
+user { $appuser: comment => $appuser }
+
+# Not needed for AWS
+file { "/home/${appuser}/.ssh/config":
+  ensure => file,
+  source => "${source_root}/deployment/ssh-config",
+  owner => $appuser,
+  group => $appgroup,
+}
+
+class { 'postgresql::globals':
+  version => '9.3',
+  encoding => 'UTF8',
+  locale => 'en_US.utf8',
+}
+class { 'postgresql::server':
+}
+class { 'postgresql::lib::devel':
+}
+postgresql::server::role { $appuser:
+  createdb => true,
+}
+->
+postgresql::server::db { 'refinery':
+  user => $appuser,
+  password => '',
+  owner => $appuser,
+}
+
+class { 'python':
+  version => 'system',
+  pip => true,
+  dev => true,
+  virtualenv => true,
+  gunicorn => false,
+}
+
+class venvdeps {
+  #TODO: peg packages to specific versions
+  package { 'build-essential': }
+  package { 'libncurses5-dev': }
+  package { 'libldap2-dev': }
+  package { 'libsasl2-dev': }
+  package { 'libffi-dev': }  # for SSL modules
+}
+include venvdeps
+
+file { "/home/${appuser}/.virtualenvs":
+  # workaround for parent directory /home/vagrant/.virtualenvs does not exist error
+  ensure => directory,
+  owner => $appuser,
+  group => $appgroup,
+}
+->
+python::virtualenv { $virtualenv:
+  ensure => present,
+  owner => $appuser,
+  group => $appgroup,
+  require => [ Class['venvdeps'], Class['postgresql::lib::devel'] ],
+}
+~>
+python::requirements { $requirements:
+  virtualenv => $virtualenv,
+  owner => $appuser,
+  group => $appgroup,
+}
+
+package { 'virtualenvwrapper': }
+->
+file_line { "virtualenvwrapper_config":
+  path => "/home/${appuser}/.profile",
+  line => "source /etc/bash_completion.d/virtualenvwrapper",
+  require => Python::Virtualenv[$virtualenv],
+}
+->
+file { "virtualenvwrapper_project":
+  # workaround for setvirtualenvproject command not found
+  ensure => file,
+  path => "${virtualenv}/.project",
+  content => "${project_root}",
+  owner => $appuser,
+  group => $appgroup,
+}
+
+file { ["${source_root}/isa-tab", "${source_root}/import", "${source_root}/static"]:
+  ensure => directory,
+  owner => $appuser,
+  group => $appgroup,
+}
+
+file_line { "django_settings_module":
+  path => "/home/${appuser}/.profile",
+  line => "export DJANGO_SETTINGS_MODULE=${django_settings_module}",
+}
+->
+file { "${project_root}/config/config.json":
+  ensure => file,
+  source => "${project_root}/config/config.json.sample",
+  owner => $appuser,
+  group => $appgroup,
+  replace => false,
+}
+->
+exec { "syncdb":
+  command => "${virtualenv}/bin/python ${project_root}/manage.py syncdb --migrate --noinput",
+  environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
+  user => $appuser,
+  group => $appgroup,
+  require => [
+               Python::Requirements[$requirements],
+               Postgresql::Server::Db["refinery"]
+             ],
+}
+->
+exec { "create_superuser":
+  command => "${virtualenv}/bin/python ${project_root}/manage.py loaddata superuser.json",
+  environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
+  user => $appuser,
+  group => $appgroup,
+}
+->
+exec { "init_refinery":
+  command => "${virtualenv}/bin/python ${project_root}/manage.py init_refinery 'Refinery' '192.168.50.50:8000'",
+  environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
+  user => $appuser,
+  group => $appgroup,
+}
+->
+exec { "create_user":
+  command => "${virtualenv}/bin/python ${project_root}/manage.py create_user 'guest' 'guest' 'guest@example.com' 'Guest' '' ''",
+  environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
+  user => $appuser,
+  group => $appgroup,
+}
+
+class solr {
+  $solr_version = "5.3.1"
+  $solr_archive = "solr-${solr_version}.tgz"
+  $solr_url = "http://archive.apache.org/dist/lucene/solr/${solr_version}/${solr_archive}"
+
+  package { 'java':
+    name => 'openjdk-7-jdk',
+  }
+
+  exec { "solr_wget":
+    command => "wget ${solr_url} -O /usr/src/${solr_archive}",
+    creates => "/usr/src/${solr_archive}",
+    path => "/usr/bin:/bin",
+    timeout => 600,  # downloading can take a long time
+  }
+  ->
+  exec { "solr_unpack_installer":
+    command => "mkdir -p /opt && tar -xzf /usr/src/${solr_archive} -C /usr/src solr-${solr_version}/bin/install_solr_service.sh --strip-components=2",
+    creates => "/opt/solr-${solr_version}",
+    path => "/usr/bin:/bin",
+  }
+  ->
+  exec { "solr_install_as_service":
+    command => "sudo bash /usr/src/install_solr_service.sh /usr/src/${solr_archive} -d ${project_root}/solr_app_data -u ${appuser} && chown -R ${appuser}:${appuser} /opt/solr-${solr_version}",
+    creates => "/opt/solr-${solr_version}",
+    path => "/usr/bin:/bin",
+  }
+  ->
+  file { "/opt/solr":
+    ensure => link,
+    target => "/opt/solr-${solr_version}",
+  }
+  ->
+  exec { "solr_stop":
+    command => "sudo service solr stop",
+    path => "/usr/bin:/bin",
+    returns => [0, 1]
+  }
+  ->
+  file_line { "solr_config_pid":
+    path => "${project_root}/solr_app_data/solr.in.sh",
+    line => "SOLR_PID_DIR=${project_root}/solr_app_data",
+    match => "^SOLR_PID_DIR"
+  }
+  ->
+  file_line { "solr_config_home":
+    path => "${project_root}/solr_app_data/solr.in.sh",
+    line => "SOLR_HOME=${project_root}/solr/",
+    match => "^SOLR_HOME"
+  }
+  ->
+  file_line { "solr_config_log4j":
+    path => "${project_root}/solr_app_data/solr.in.sh",
+    line => "LOG4J_PROPS=${project_root}/solr/log4j.properties",
+    match => "^LOG4J_PROPS"
+  }
+  ->
+  file_line { "solr_config_log_dir":
+    path => "${project_root}/solr_app_data/solr.in.sh",
+    line => "SOLR_LOGS_DIR=${project_root}/log",
+    match => "^SOLR_LOGS_DIR"
+  }
+}
+include solr
+
+class neo4j {
+  $neo4j_version = "2.3.0"
+  $neo4j_name = "neo4j-community-${neo4j_version}"
+  $neo4j_archive = "${neo4j_name}-unix.tar.gz"
+  $neo4j_url = "http://neo4j.com/artifact.php?name=${neo4j_archive}"
+
+  exec { "neo4j_wget":
+    command => "wget ${neo4j_url} -O /usr/src/${neo4j_archive}",
+    creates => "/usr/src/${neo4j_archive}",
+    path => "/usr/bin:/bin",
+    timeout => 600,  # downloading can take a long time
+  }
+  ->
+  exec { "neo4j_unpack":
+    command => "mkdir -p /opt && tar -xzf /usr/src/${neo4j_archive} -C /opt && chown -R ${appuser}:${appuser} /opt/${neo4j_name}",
+    creates => "/opt/${neo4j_name}",
+    path => "/usr/bin:/bin",
+  }
+  ->
+  file { "/opt/neo4j":
+    ensure => link,
+    target => "${neo4j_name}",
+  }
+  ->
+  file { "/opt/neo4j-data":
+    ensure => 'directory',
+    owner  => "${appuser}",
+    group  => "${appgroup}",
+  }
+  ->
+  file_line { "neo4j_graph_db_location":
+    path => "/opt/${neo4j_name}/conf/neo4j-server.properties",
+    line => "org.neo4j.server.database.location=/opt/neo4j-data/graph.db",
+    match => "^org.neo4j.server.database.location=",
+  }
+  ->
+  file_line { "neo4j_no_authentication":
+    path => "/opt/${neo4j_name}/conf/neo4j-server.properties",
+    line => "dbms.security.auth_enabled=false",
+    match => "^dbms.security.auth_enabled=",
+  }
+  ->
+  file_line { "neo4j_all_ips":
+    path => "/opt/${neo4j_name}/conf/neo4j-server.properties",
+    line => "org.neo4j.server.webserver.address=0.0.0.0",
+    match => "^#org.neo4j.server.webserver.address=",
+  }
+  limits::fragment {
+    "vagrant/soft/nofile":
+      value => "40000";
+    "vagrant/hard/nofile":
+      value => "40000";
+  }
+}
+include neo4j
+
+class owl2neo4j {
+  $owl2neo4j_version = "0.3.3"
+  $owl2neo4j_url = "https://github.com/flekschas/owl2neo4j/releases/download/v${owl2neo4j_version}/owl2neo4j.jar"
+
+  # Need to remove the old file manually as wget throws a weird
+  # `HTTP request sent, awaiting response... 403 Forbidden` error when the file
+  # already exists.
+
+  exec { "owl2neo4j_wget":
+    command => "rm -f /opt/owl2neo4j.jar && wget -P /opt/ ${owl2neo4j_url}",
+    creates => "/opt/owl2neo4j",
+    path => "/usr/bin:/bin",
+    timeout => 120,  # downloading can take some time
+  }
+}
+include owl2neo4j
+
+class rabbit {
+  package { 'curl': }
+  ->
+  class { '::rabbitmq':
+    package_ensure => installed,
+    service_ensure => running,
+    port => '5672',
+  }
+}
+include rabbit
+
+class ui {
+  # need a version of Node that's more recent than one included with Ubuntu 12.04
+  # apt::ppa { 'ppa:chris-lea/node.js': }
+  include apt
+
+  apt::source { 'nodejs':
+    ensure      => 'present',
+    comment     => 'Nodesource NodeJS repo.',
+    location    => 'https://deb.nodesource.com/node_4.x',
+    release     => 'trusty',
+    repos       => 'main',
+    key         => '9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280',
+    key_server  => 'keyserver.ubuntu.com',
+    include_src => true,
+    include_deb => true
+  }
+
+  package { 'nodejs':
+    name => 'nodejs',
+    ensure  => latest,
+    require => Apt::Source['nodejs']
+  }
+  ->
+  package {
+    'bower': ensure => '1.6.5', provider => 'npm';
+    'grunt-cli': ensure => '0.1.13', provider => 'npm';
+  }
+  ->
+  exec { "npm_local_modules":
+    command => "/usr/bin/npm prune && /usr/bin/npm install",
+    cwd => $ui_app_root,
+    logoutput => on_failure,
+    user => $appuser,
+    group => $appgroup,
+  }
+  ->
+  exec { "bower_modules":
+    command => "/usr/bin/bower prune && /usr/bin/bower install --config.interactive=false",
+    cwd => $ui_app_root,
+    logoutput => on_failure,
+    user => $appuser,
+    group => $appgroup,
+    environment => ["HOME=/home/${appuser}"],
+  }
+  ->
+  exec { "grunt":
+    command => "/usr/bin/grunt build && /usr/bin/grunt compile",
+    cwd => $ui_app_root,
+    logoutput => on_failure,
+    user => $appuser,
+    group => $appgroup,
+  }
+  ->
+  exec { "collectstatic":
+    command => "${virtualenv}/bin/python ${project_root}/manage.py collectstatic --clear --noinput",
+    environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
+    user => $appuser,
+    group => $appgroup,
+    require => Python::Requirements[$requirements],
+  }
+}
+include ui
+
+file { "${project_root}/supervisord.conf":
+  ensure => file,
+  source => "${project_root}/supervisord.conf.sample",
+  owner => $appuser,
+  group => $appgroup,
+}
+->
+exec { "supervisord":
+  command => "${virtualenv}/bin/supervisord",
+  environment => ["DJANGO_SETTINGS_MODULE=${django_settings_module}"],
+  cwd => $project_root,
+  creates => "/tmp/supervisord.pid",
+  user => $appuser,
+  group => $appgroup,
+  require => [ Class["ui"], Class["solr"], Class["neo4j"], Class ["rabbit"] ],
+}
+
+package { 'libapache2-mod-wsgi': }
+package { 'apache2': }
+exec { 'apache2-wsgi':
+  command => '/usr/sbin/a2enmod wsgi',
+  subscribe => [ Package['apache2'], Package['libapache2-mod-wsgi'] ],
+}
+->
+file { "/etc/apache2/sites-available/001-refinery.conf":
+  ensure => file,
+  content => template("${source_root}/deployment/apache.conf"),
+}
+~>
+exec { 'refinery-apache2':
+  command => '/usr/sbin/a2ensite 001-refinery',
+}
+~>
+service { 'apache2':
+  ensure => running,
+  hasrestart => true,
+}
+
+package { 'memcached': }
+service { 'memcached':
+  ensure => running,
+}

--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -3,3 +3,5 @@ ecdsa==0.11
 fabtools==0.19.0
 paramiko==1.14.0
 pycrypto==2.6.1
+cfn-pyplates==0.5.0
+awscli==1.8.13


### PR DESCRIPTION
documentation in `deployment/AWS.md`

At the moment, this uses separate copies of the Puppet manifest (`aws.pp` instead of `default.pp`), `apache.conf` (templated via `apache.conf.erb` instead of `apache.conf`) and `config.json` (edited on startup via a hacky `sed` script).

Next step (after this PR is merged) will be fix those issues.