### PR TITLE
Fix postgresql for "vagrant provision"

### DIFF
--- a/deployment/manifests/default.pp
+++ b/deployment/manifests/default.pp
@@ -14,5 +14,5 @@ class { 'timezone':
 }
 
 # See code in refinery-modules/refinery/...
-include postgresql
 include refinery
+include refinery::pg

--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -13,28 +13,6 @@ file { "/home/${app_user}/.ssh/config":
   group  => $app_group,
 }
 
-class { 'postgresql::globals':
-  version  => '9.3',
-  encoding => 'UTF8',
-  locale   => 'en_US.utf8',
-}
-
-class { 'postgresql::server':
-}
-
-class { 'postgresql::lib::devel':
-}
-
-postgresql::server::role { $app_user:
-  createdb => true,
-}
-->
-postgresql::server::db { 'refinery':
-  user     => $app_user,
-  password => '',
-  owner    => $app_user,
-}
-
 class { 'python':
   version    => 'system',
   pip        => true,

--- a/deployment/refinery-modules/refinery/manifests/pg.pp
+++ b/deployment/refinery-modules/refinery/manifests/pg.pp
@@ -1,4 +1,4 @@
-class postgresql {
+class refinery::pg {
 class { 'postgresql::globals':
   version  => '9.3',
   encoding => 'UTF8',


### PR DESCRIPTION
The ppostgresql part of `vagrant provision` was broken (by me).

I think this fixes that, but for me `vagrant provision` now falls over for a different reason, and I'm not sure what's going on.