### PR TITLE
Fixing the postgresql rules on AWS

### DIFF
--- a/deployment/manifests/aws.pp
+++ b/deployment/manifests/aws.pp
@@ -12,4 +12,5 @@ $ui_app_root = "${django_root}/ui"
 
 # See code in refinery-modules/refinery/...
 include refinery
+include refinery::pg
 include refinery::aws


### PR DESCRIPTION
Short version: It's simpler to configure AWS instance with an unused postgresql installation than
work out how to convince puppet that some requirements do not always apply.

before this PR the AWS isntallation was broken because various things in puppet depend on the postgresql installation which I removed for AWS. EG https://github.com/parklab/refinery-platform/blob/a285340a600b116ca133b391ae2106173cbde4e0/deployment/refinery-modules/refinery/manifests/init.pp#L96