### PR TITLE
Set the Availability Zone for the new EC2 instance

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -5,3 +5,4 @@ paramiko==1.14.0
 pycrypto==2.6.1
 cfn-pyplates==0.5.0
 awscli==1.8.13
+boto3==1.2.3


### PR DESCRIPTION
Fixing a bug where `make web-stack` would fail when it created an instance in a different Availability Zone to the existing Volume that it was trying to attach.

Took a surprisingly long time to find because the preferred Availability Zone seems to be a bit "sticky".