### PR TITLE
Put filesystem directly on external device

### DIFF
--- a/deployment/refinery-modules/refinery/manifests/aws.pp
+++ b/deployment/refinery-modules/refinery/manifests/aws.pp
@@ -6,21 +6,11 @@ class refinery::aws {
 
 $fstype = 'ext3'
 
-package { 'lvm2':
-  ensure => present,
-}
-->
-volume_group { 'refinerydata':
-  ensure => present,
-  physical_volumes => '/dev/xvdr',
-}
-->
-logical_volumes { 'data':
-  ensure => present,
-  volume_group => 'refinerydata',
-}
-->
-filesystem { '/dev/refinerydata/data/':
+# This is the block device for the external data.
+# It must match the attachment point for the EC2 EBS volume.
+$block_device = '/dev/xvdr'
+
+filesystem { $block_device:
   ensure => present,
   fstype => $fstype,
 }
@@ -32,7 +22,7 @@ file { '/data':
 ->
 mount { '/data':
   ensure => mounted,
-  device => '/dev/refinerydata/data',
+  device => $block_device,
   fstype => $fstype,
   options => 'defaults',
 }

--- a/deployment/refinery-modules/refinery/manifests/aws.pp
+++ b/deployment/refinery-modules/refinery/manifests/aws.pp
@@ -10,10 +10,18 @@ package { 'lvm2':
   ensure => present,
 }
 ->
-lvm::volume { 'data':
+volume_group { 'refinerydata':
   ensure => present,
-  vg     => 'refinerydata',
-  pv     => '/dev/xvdr',
+  physical_volumes => '/dev/xvdr',
+}
+->
+logical_volumes { 'data':
+  ensure => present,
+  volume_group => 'refinerydata',
+}
+->
+filesystem { '/dev/refinerydata/data/':
+  ensure => present,
   fstype => $fstype,
 }
 ->

--- a/deployment/refinery-modules/refinery/manifests/aws.pp
+++ b/deployment/refinery-modules/refinery/manifests/aws.pp
@@ -12,7 +12,7 @@ $block_device = '/dev/xvdr'
 
 filesystem { $block_device:
   ensure => present,
-  fstype => $fstype,
+  fs_type => $fstype,
 }
 ->
 # Mountpoint


### PR DESCRIPTION
This fixes #883 by avoiding the LVM indirection and instead formatting the block device directly.

It works (at least when I tested it) for both completely fresh volumes and previously used volumes.