### PR TITLE
Create fresh role for EC2 instance

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -4,7 +4,7 @@ web.json: .PHONY
 	python stack.py > web.json
 
 web-stack: web.json .PHONY
-	aws cloudformation create-stack --stack-name refinery-web-$$(date +%Y%m%dT%H%M) --template-body file://web.json
+	aws cloudformation create-stack --capabilities CAPABILITY_IAM --stack-name refinery-web-$$(date +%Y%m%dT%H%M) --template-body file://web.json
 
 volume.json: .PHONY
 	python volume_cfn.py > volume.json

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -96,8 +96,57 @@ def main():
             'InstanceType': 'm3.medium',
             'UserData': functions.base64(user_data_script),
             'KeyName': 'id_rsa',
-            'IamInstanceProfile': 'refinery-web',
+            'IamInstanceProfile': functions.ref('WebInstanceProfile'),
             'Tags': tags.load(),
+        })
+    )
+
+    cft.resources.instance_profile = core.Resource(
+        'WebInstanceProfile', 'AWS::IAM::InstanceProfile',
+        core.Properties({
+            'Path': '/',
+            'Roles': [
+              functions.ref('WebInstanceRole')
+            ]
+        })
+    )
+
+    cft.resources.web_role = core.Resource(
+        'WebInstanceRole', 'AWS::IAM::Role',
+        core.Properties({
+            # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iam-role.html#cfn-iam-role-templateexamples
+            "AssumeRolePolicyDocument": {
+               "Version": "2012-10-17",
+               "Statement": [{
+                  "Effect": "Allow",
+                  "Principal": {
+                     "Service": ["ec2.amazonaws.com"]
+                  },
+                  "Action": ["sts:AssumeRole"]
+               }]
+            },
+            'ManagedPolicyArns': [
+                'arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess',
+                'arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess'
+            ],
+            'Path': '/',
+            'Policies': [{
+                'PolicyName': "CreateAccessKey",
+                'PolicyDocument': {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "iam:CreateAccessKey"
+                            ],
+                            "Resource": [
+                                "*"
+                            ]
+                        }
+                    ]
+                }
+            }]
         })
     )
 


### PR DESCRIPTION
Creating the role is now pushed into the Cloud Formation template, which eliminates the need to create it "by hand" first.

- [x] update the documentation in the wiki