### PR TITLE
template supervisord.conf for AWS

### DIFF
--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -360,10 +360,10 @@ service { 'memcached':
 }
 
 file { "${django_root}/supervisord.conf":
-  ensure => file,
-  source => "${django_root}/supervisord.conf.sample",
-  owner  => $app_user,
-  group  => $app_group,
+  ensure  => file,
+  content => template("${django_root}/supervisord.conf.erb"),
+  owner   => $app_user,
+  group   => $app_group,
 }
 ->
 exec { "supervisord":

--- a/refinery/supervisord.conf.erb
+++ b/refinery/supervisord.conf.erb
@@ -48,7 +48,7 @@ priority = 995
 [program:worker2]
 ; limits concurrency of file imports to one to avoid overloading system IO
 command = python %(here)s/manage.py celeryd -c 1 -Q file_import --events
-environment = PATH="< @virtualenv %>/bin"
+environment = PATH="<% @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celeryd-w2.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -65,7 +65,7 @@ priority = 995
 
 [program:celerycam]
 command = python %(here)s/manage.py celerycam
-environment = PATH="< @virtualenv %>/bin"
+environment = PATH="<% @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celerycam.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -77,7 +77,7 @@ priority= 994
 
 [program:celerybeat]
 command = python %(here)s/manage.py celerybeat
-environment = PATH="< @virtualenv %>/bin"
+environment = PATH="<% @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celerybeat.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -89,7 +89,7 @@ priority= 996
 
 [program:runserver]
 command = python %(here)s/manage.py runserver 0.0.0.0:8000 --noreload
-environment = PATH="< @virtualenv %>/bin"
+environment = PATH="<% @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/refinery.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4

--- a/refinery/supervisord.conf.erb
+++ b/refinery/supervisord.conf.erb
@@ -30,7 +30,7 @@ priority = 995
 [program:worker1]
 ; minimum of four processes required to avoid problems with monitoring tasks
 command = python %(here)s/manage.py celeryd -c 4 -Q celery --events
-environment = PATH="/home/vagrant/.virtualenvs/refinery-platform/bin"
+environment = PATH="<%= @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celeryd-w1.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -48,7 +48,7 @@ priority = 995
 [program:worker2]
 ; limits concurrency of file imports to one to avoid overloading system IO
 command = python %(here)s/manage.py celeryd -c 1 -Q file_import --events
-environment = PATH="/home/vagrant/.virtualenvs/refinery-platform/bin"
+environment = PATH="< @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celeryd-w2.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -65,7 +65,7 @@ priority = 995
 
 [program:celerycam]
 command = python %(here)s/manage.py celerycam
-environment = PATH="/home/vagrant/.virtualenvs/refinery-platform/bin"
+environment = PATH="< @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celerycam.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -77,7 +77,7 @@ priority= 994
 
 [program:celerybeat]
 command = python %(here)s/manage.py celerybeat
-environment = PATH="/home/vagrant/.virtualenvs/refinery-platform/bin"
+environment = PATH="< @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celerybeat.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -89,7 +89,7 @@ priority= 996
 
 [program:runserver]
 command = python %(here)s/manage.py runserver 0.0.0.0:8000 --noreload
-environment = PATH="/home/vagrant/.virtualenvs/refinery-platform/bin"
+environment = PATH="< @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/refinery.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4


### PR DESCRIPTION
This was delayed by some neo4j problems, but I think they are all sorted now.

Now `supervisord` starts, but the things it supervises have problems:

![supervisord](https://cloud.githubusercontent.com/assets/1215412/13643207/a84dd306-e617-11e5-8242-dd4f4e540371.png)
