### PR TITLE
Fix typo in erb syntax for supervisord.conf

### DIFF
--- a/refinery/supervisord.conf.erb
+++ b/refinery/supervisord.conf.erb
@@ -48,7 +48,7 @@ priority = 995
 [program:worker2]
 ; limits concurrency of file imports to one to avoid overloading system IO
 command = python %(here)s/manage.py celeryd -c 1 -Q file_import --events
-environment = PATH="<% @virtualenv %>/bin"
+environment = PATH="<%= @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celeryd-w2.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -65,7 +65,7 @@ priority = 995
 
 [program:celerycam]
 command = python %(here)s/manage.py celerycam
-environment = PATH="<% @virtualenv %>/bin"
+environment = PATH="<%= @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celerycam.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -77,7 +77,7 @@ priority= 994
 
 [program:celerybeat]
 command = python %(here)s/manage.py celerybeat
-environment = PATH="<% @virtualenv %>/bin"
+environment = PATH="<%= @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/celerybeat.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4
@@ -89,7 +89,7 @@ priority= 996
 
 [program:runserver]
 command = python %(here)s/manage.py runserver 0.0.0.0:8000 --noreload
-environment = PATH="<% @virtualenv %>/bin"
+environment = PATH="<%= @virtualenv %>/bin"
 stdout_logfile = %(here)s/log/refinery.log
 stdout_logfile_maxbytes = 5MB
 stdout_logfile_backups = 4


### PR DESCRIPTION
Proper fix for  #937

This one works (I should've been more skeptical before):
```
ubuntu@ip-172-31-57-18:~$ . ~/.virtualenvs/refinery-platform/bin/activate
(refinery-platform)ubuntu@ip-172-31-57-18:~$ supervisorctl status
celerybeat                       RUNNING   pid 21078, uptime 2:58:10
celerycam                        RUNNING   pid 21075, uptime 2:58:10
celeryd:worker1                  RUNNING   pid 21076, uptime 2:58:10
celeryd:worker2                  RUNNING   pid 21077, uptime 2:58:10
runserver                        RUNNING   pid 21079, uptime 2:58:10
```