### PR TITLE
Move solr data to persistent volume

### DIFF
--- a/deployment/manifests/aws.pp
+++ b/deployment/manifests/aws.pp
@@ -16,6 +16,10 @@ $ui_app_root = "${django_root}/ui"
 # $site_name set by Facter
 # $site_url set by Facter
 
+# solr is in the /data volume on AWS:
+$solr_data_set_manager_data = "/data/solr/data_set_manager"
+$solr_core_data = "/data/solr/core"
+
 # See code in refinery-modules/refinery/...
 include refinery
 include refinery::pg

--- a/deployment/refinery-modules/refinery/manifests/aws.pp
+++ b/deployment/refinery-modules/refinery/manifests/aws.pp
@@ -41,6 +41,14 @@ file { '/data/isa-tab':
   mode => "0755",
 }
 ->
+file { "/data/solr":
+  ensure => directory,
+  owner => "$app_user",
+  group => "$app_user",
+  mode => "0755",
+  before => Exec["solr_install"],
+}
+->
 file { "$solr_data_set_manager_data":
   ensure => directory,
   owner => "$app_user",

--- a/deployment/refinery-modules/refinery/manifests/aws.pp
+++ b/deployment/refinery-modules/refinery/manifests/aws.pp
@@ -40,6 +40,20 @@ file { '/data/isa-tab':
   group => "$app_user",
   mode => "0755",
 }
+->
+file { "$solr_data_set_manager_data":
+  ensure => directory,
+  owner => "$app_user",
+  group => "$app_user",
+  mode => "0755",
+}
+->
+file { "$solr_core_data":
+  ensure => directory,
+  owner => "$app_user",
+  group => "$app_user",
+  mode => "0755",
+}
 
 
 python::requirements { "/srv/refinery-platform/deployment/aws-requirements.txt":

--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -145,6 +145,16 @@ class solr {
     path    => "/bin",
   }
   ->
+  file { "${django_root}/solr/core/conf/solrconfig.xml":
+    ensure  => file,
+    content => template("${django_root}/solr/core/conf/solrconfig.xml.erb"),
+  }
+  ->
+  file { "${django_root}/solr/data_set_manager/conf/solrconfig.xml":
+    ensure  => file,
+    content => template("${django_root}/solr/data_set_manager/conf/solrconfig.xml.erb"),
+  }
+  ->
   exec { "solr_install":  # also starts the service
     command => "sudo bash ./install_solr_service.sh ${solr_archive} -u ${app_user}",
     cwd     => "/usr/local/src",

--- a/refinery/solr/core/conf/solrconfig.xml.erb
+++ b/refinery/solr/core/conf/solrconfig.xml.erb
@@ -111,7 +111,7 @@
        replication is in use, this should match the replication
        configuration.
     -->
-  <dataDir>${solr.data.dir:}</dataDir>
+  <dataDir><%= @solr_core_data || "${solr.data.dir:}" %></dataDir>
 
 
   <!-- The DirectoryFactory to use for indexes.
@@ -1619,4 +1619,51 @@
       -->
   </admin>
 
+  <!-- Main configuration for a synonym-expanding ExtendedDismaxQParserPlugin.  See
+       https://github.com/healthonnet/hon-lucene-synonyms
+       for more info on this plugin.
+    -->
+  <queryParser name="synonym_edismax" class="solr.SynonymExpandingExtendedDismaxQParserPlugin">
+    <!-- You can define more than one synonym analyzer in the following list.
+         For example, you might have one set of synonyms for English, one for French,
+         one for Spanish, etc.
+      -->
+    <lst name="synonymAnalyzers">
+      <!-- Name your analyzer something useful, e.g. "analyzer_en", "analyzer_fr", "analyzer_es", etc.
+           If you only have one, the name doesn't matter (hence "myCoolAnalyzer").
+        -->
+      <lst name="search_synonym_analyzer_en">
+        <!-- We recommend a PatternTokenizerFactory that tokenizes based on whitespace and quotes.
+             This seems to work best with most people's synonym files.
+             For details, read the discussion here: http://github.com/healthonnet/hon-lucene-synonyms/issues/26
+          -->
+        <lst name="tokenizer">
+          <str name="class">solr.PatternTokenizerFactory</str>
+          <str name="pattern"><![CDATA[(?:\s|\")+]]></str>
+        </lst>
+        <!-- The ShingleFilterFactory outputs synonyms of multiple token lengths (e.g. unigrams, bigrams, trigrams, etc.).
+             The default here is to assume you don't have any synonyms longer than 4 tokens.
+             You can tweak this depending on what your synonyms look like. E.g. if you only have unigrams, you can remove
+             it entirely, and if your synonyms are up to 7 tokens in length, you should set the maxShingleSize to 7.
+          -->
+        <lst name="filter">
+          <str name="class">solr.ShingleFilterFactory</str>
+          <str name="outputUnigramsIfNoShingles">true</str>
+          <str name="outputUnigrams">true</str>
+          <str name="minShingleSize">2</str>
+          <str name="maxShingleSize">4</str>
+        </lst>
+        <!-- This is where you set your synonym file.  For the unit tests and "Getting Started" examples, we use example_synonym_file.txt.
+             This plugin will work best if you keep expand set to true and have all your synonyms comma-separated (rather than =>-separated).
+          -->
+        <lst name="filter">
+          <str name="class">solr.SynonymFilterFactory</str>
+          <str name="tokenizerFactory">solr.KeywordTokenizerFactory</str>
+          <str name="synonyms">custom-synonyms.txt</str>
+          <str name="expand">true</str>
+          <str name="ignoreCase">true</str>
+        </lst>
+      </lst>
+    </lst>
+  </queryParser>
 </config>

--- a/refinery/solr/data_set_manager/conf/solrconfig.xml.erb
+++ b/refinery/solr/data_set_manager/conf/solrconfig.xml.erb
@@ -111,7 +111,7 @@
        replication is in use, this should match the replication
        configuration.
     -->
-  <dataDir>${solr.data.dir:}</dataDir>
+  <dataDir><%= @solr_data_set_manager_data || "${solr.data.dir:}" %></dataDir>
 
 
   <!-- The DirectoryFactory to use for indexes.
@@ -1619,51 +1619,4 @@
       -->
   </admin>
 
-  <!-- Main configuration for a synonym-expanding ExtendedDismaxQParserPlugin.  See
-       https://github.com/healthonnet/hon-lucene-synonyms
-       for more info on this plugin.
-    -->
-  <queryParser name="synonym_edismax" class="solr.SynonymExpandingExtendedDismaxQParserPlugin">
-    <!-- You can define more than one synonym analyzer in the following list.
-         For example, you might have one set of synonyms for English, one for French,
-         one for Spanish, etc.
-      -->
-    <lst name="synonymAnalyzers">
-      <!-- Name your analyzer something useful, e.g. "analyzer_en", "analyzer_fr", "analyzer_es", etc.
-           If you only have one, the name doesn't matter (hence "myCoolAnalyzer").
-        -->
-      <lst name="search_synonym_analyzer_en">
-        <!-- We recommend a PatternTokenizerFactory that tokenizes based on whitespace and quotes.
-             This seems to work best with most people's synonym files.
-             For details, read the discussion here: http://github.com/healthonnet/hon-lucene-synonyms/issues/26
-          -->
-        <lst name="tokenizer">
-          <str name="class">solr.PatternTokenizerFactory</str>
-          <str name="pattern"><![CDATA[(?:\s|\")+]]></str>
-        </lst>
-        <!-- The ShingleFilterFactory outputs synonyms of multiple token lengths (e.g. unigrams, bigrams, trigrams, etc.).
-             The default here is to assume you don't have any synonyms longer than 4 tokens.
-             You can tweak this depending on what your synonyms look like. E.g. if you only have unigrams, you can remove
-             it entirely, and if your synonyms are up to 7 tokens in length, you should set the maxShingleSize to 7.
-          -->
-        <lst name="filter">
-          <str name="class">solr.ShingleFilterFactory</str>
-          <str name="outputUnigramsIfNoShingles">true</str>
-          <str name="outputUnigrams">true</str>
-          <str name="minShingleSize">2</str>
-          <str name="maxShingleSize">4</str>
-        </lst>
-        <!-- This is where you set your synonym file.  For the unit tests and "Getting Started" examples, we use example_synonym_file.txt.
-             This plugin will work best if you keep expand set to true and have all your synonyms comma-separated (rather than =>-separated).
-          -->
-        <lst name="filter">
-          <str name="class">solr.SynonymFilterFactory</str>
-          <str name="tokenizerFactory">solr.KeywordTokenizerFactory</str>
-          <str name="synonyms">custom-synonyms.txt</str>
-          <str name="expand">true</str>
-          <str name="ignoreCase">true</str>
-        </lst>
-      </lst>
-    </lst>
-  </queryParser>
 </config>


### PR DESCRIPTION
This PR moves the solr data to the `/data` volume.

I have tested this by adding a dataset and then deleting the stack and recreating it. The dataset still appears to be intact, but I'm not sure I would be able to tell if it was wrong.

![dataset](https://cloud.githubusercontent.com/assets/1215412/14643933/386b900e-0648-11e6-83df-26e237531dc3.png)
