### PR TITLE
Refactoring how aws region is discovered

### DIFF
--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# aws.sh
 
 set -x
 

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -26,6 +26,13 @@ sudo su -c '
 
 cd /srv/refinery-platform/deployment
 
+# Write AWS region to file (for later use).
+export AWS_DEFAULT_REGION       # Set by inline cloudinit script.
+if [ ! -z "$AWS_DEFAULT_REGION" ]
+then
+    printf '%s\n' "$AWS_DEFAULT_REGION" > /home/ubuntu/region
+fi
+
 # Set by inline cloudinit script.
 export S3_CONFIG_URI
 # Write s3-config to /home/ubuntu/s3-config

--- a/deployment/bin/aws-rds-endpoint
+++ b/deployment/bin/aws-rds-endpoint
@@ -23,10 +23,7 @@
 
 Rdsname=${1?RDS Name}
 
-Region=$(
-  curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document |
-  jq -r .region
-)
+Region=$(cat /home/ubuntu/region)
 
 # To find the connection details for a db instance with a known name
 aws --region "$Region" rds describe-db-instances |

--- a/deployment/bin/get-s3-config
+++ b/deployment/bin/get-s3-config
@@ -6,9 +6,6 @@
 
 : ${S3_CONFIG_URI?S3_CONFIG_URI should be set}
 
-Region=$(
-  curl --silent http://169.254.169.254/latest/dynamic/instance-identity/document |
-  jq -r .region
-)
+Region=$(cat /home/ubuntu/region)
 
 aws s3 --region "$Region" cp "$S3_CONFIG_URI" s3-config

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -84,6 +84,7 @@ def main():
     user_data_script = functions.join(
         "",
         "#!/bin/sh\n",
+        "AWS_DEFAULT_REGION=", functions.ref("AWS::Region"), "\n",
         "RDS_NAME=", config['RDS_NAME'], "\n",
         "RDS_SUPERUSER_PASSWORD=", config['RDS_SUPERUSER_PASSWORD'], "\n",
         "RDS_ROLE=", config['RDS_ROLE'], "\n",


### PR DESCRIPTION
Prompted by http://stackoverflow.com/a/24123651/242457 I realised you can get the AWS region from the CloudFormation template, which is a lot simpler.

It's not a huge difference, but it is a bit clearer now.