### PR TITLE
Make the AWS EC2 instance key name configurable

### DIFF
--- a/deployment/aws-config/10default.yaml
+++ b/deployment/aws-config/10default.yaml
@@ -22,7 +22,8 @@ SITE_NAME: Refinery
 SITE_URL: "192.168.50.50:8000"
 
 # The name of the EC2 key pair to use for SSH.
-# FIXED to "id_rsa".
+# (this key pair is required to already exist in the AWS account)
+# KEY_NAME: "id_rsa"
 
 # The AMI image for the EC2 instance
 # FIXED to "ami-d05e75b8"

--- a/deployment/stack.py
+++ b/deployment/stack.py
@@ -163,7 +163,7 @@ def main():
             'ImageId': 'ami-d05e75b8',
             'InstanceType': 'm3.medium',
             'UserData': functions.base64(user_data_script),
-            'KeyName': 'ngehlenborg-test_rsa',
+            'KeyName': config['KEY_NAME'],
             'IamInstanceProfile': functions.ref('WebInstanceProfile'),
             'Tags': instance_tags,
         })
@@ -306,6 +306,9 @@ def load_config():
     config.setdefault('RDS_SUPERUSER_PASSWORD', 'mypassword')
     if 'RDS_NAME' not in config:
         config['RDS_NAME'] = "rds-refinery-" + random_alnum(7)
+
+    if 'KEY_NAME' not in config:
+        config['KEY_NAME'] = 'id_rsa'
 
     return config
 


### PR DESCRIPTION
The SSH Key Pair name defaults to `id_rsa`; set `KEY_NAME` to use a different one.

Undoes the accidentally `stack.py` change introduced in 207d74c3144e32da4e78082385c17ef93622fea6