### PR TITLE
Celery amqp import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-amqplib==1.0.2
 anyjson==0.3.1
 argh==0.23.1
 bioblend==0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# workaround for https://github.com/celery/celery/issues/3225
+amqp==1.4.9
 anyjson==0.3.1
 argh==0.23.1
 bioblend==0.5.0


### PR DESCRIPTION
Retire amqplib and apply workaround to address https://github.com/celery/celery/issues/3225
