### PR TITLE
Fix location of solr plugin in AWS

### DIFF
--- a/deployment/manifests/aws.pp
+++ b/deployment/manifests/aws.pp
@@ -10,7 +10,8 @@ $media_root = "/data/media"
 $import_dir = "/data/import"
 $solr_custom_synonyms_file =
   "${django_root}/solr/core/conf/custom-synonyms.txt"
-$solr_lib_dir = "${django_root}/solr/lib"
+# As per https://github.com/parklab/refinery-platform/issues/1153
+$solr_lib_dir = "/opt/solr/server/solr-webapp/webapp/WEB-INF/lib"
 $email_host = "email-smtp.us-east-1.amazonaws.com"
 # $email_host_user set by Facter
 # $email_host_password set by Facter

--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -238,6 +238,7 @@ class solrSynonymAnalyzer {
     path    => "/usr/bin:/bin",
     timeout => 120,  # downloading can take some time
     notify => Service['solr'],
+    require => Exec['solr_install'],
   }
 }
 include solrSynonymAnalyzer

--- a/deployment/refinery-modules/refinery/manifests/init.pp
+++ b/deployment/refinery-modules/refinery/manifests/init.pp
@@ -233,8 +233,8 @@ class solrSynonymAnalyzer {
   # already exists.
 
   exec { "solr-synonym-analyzer-download":
-    command => "rm -f /vagrant/refinery/solr/lib/hon-lucene-synonyms.jar && wget -P /vagrant/refinery/solr/lib/ ${url}",
-    creates => "/vagrant/refinery/solr/lib/hon-lucene-synonyms.jar",
+    command => "rm -f ${solr_lib_dir}/hon-lucene-synonyms.jar && wget -P ${solr_lib_dir} ${url}",
+    creates => "${solr_lib_dir}/hon-lucene-synonyms.jar",
     path    => "/usr/bin:/bin",
     timeout => 120,  # downloading can take some time
     notify => Service['solr'],


### PR DESCRIPTION
Moves the `hon-lucene-synonyms.jar` solr plugin to `/opt/solr/./server/solr-webapp/webapp/WEB-INF/lib/`.

Fixes https://github.com/parklab/refinery-platform/issues/1153