### PR TITLE
Add users with SSH_USERS

### DIFF
--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -8,6 +8,8 @@ set -x
 # to both Vagrant and AWS. Both bootstrap.sh and aws.sh (this
 # script) are supplied via cloudinit userdata.
 
+env
+
 # Normally supplied as input, but use a default if not.
 GIT_BRANCH=${GIT_BRANCH:-develop}
 

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -39,6 +39,11 @@ export S3_CONFIG_URI
 (cd /home/ubuntu &&
  /srv/refinery-platform/deployment/bin/get-s3-config)
 
+# List of SSH users
+SSH_USERS=$(jq -r '"" + .SSH_USERS' < /home/ubuntu/s3-config) 
+# Deliberately field split to get several users.
+sh /srv/refinery-platform/deployment/bin/fetch-github-ssh-keys $SSH_USERS
+
 # Tag the attached root volume
 sh /srv/refinery-platform/deployment/bin/fix-untagged-volumes
 

--- a/deployment/aws.sh
+++ b/deployment/aws.sh
@@ -44,7 +44,7 @@ export S3_CONFIG_URI
 # List of SSH users
 SSH_USERS=$(jq -r '"" + .SSH_USERS' < /home/ubuntu/s3-config) 
 # Deliberately field split to get several users.
-sh /srv/refinery-platform/deployment/bin/fetch-github-ssh-keys $SSH_USERS
+HOME=/home/ubuntu sh /srv/refinery-platform/deployment/bin/fetch-github-ssh-keys $SSH_USERS
 
 # Tag the attached root volume
 sh /srv/refinery-platform/deployment/bin/fix-untagged-volumes

--- a/deployment/bin/fetch-github-ssh-keys
+++ b/deployment/bin/fetch-github-ssh-keys
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# A script to fetch public SSH keys from github,
+# and append them to ~/.ssh/authorized_keys
+
+# The list of github users,
+# should be the command line arguments to this script.
+
+# jq and curl are both required.
+
+for u in "$@"
+do
+    curl https://api.github.com/users/"$u"/keys |
+    jq -r '.[].key'
+done >> ~/.ssh/authorized_keys


### PR DESCRIPTION
Can now add SSH users automatically at boot time by using the key `SSH_USERS` in the `aws-config/config.yaml`.

- [x] which needs documenting.