### PR TITLE
Add Private IP to ALLOWED_HOSTS

### DIFF
--- a/refinery/config/settings/aws.py
+++ b/refinery/config/settings/aws.py
@@ -6,6 +6,8 @@
 # Like prod, but overriding some things.
 from .prod import *  # NOQA
 
+import requests
+
 # Ensure that the AWS private IP is an Allowed Host.
 # (required for ELB pings to work,
 # see https://github.com/parklab/refinery-platform/issues/1239)

--- a/refinery/config/settings/aws.py
+++ b/refinery/config/settings/aws.py
@@ -3,10 +3,10 @@
 # See https://github.com/parklab/refinery-platform/wiki/AWS for
 # more details.
 
+import requests
+
 # Like prod, but overriding some things.
 from .prod import *  # NOQA
-
-import requests
 
 # Ensure that the AWS private IP is an Allowed Host.
 # (required for ELB pings to work,

--- a/refinery/config/settings/aws.py
+++ b/refinery/config/settings/aws.py
@@ -6,6 +6,17 @@
 # Like prod, but overriding some things.
 from .prod import *  # NOQA
 
+# Ensure that the AWS private IP is an Allowed Host.
+# (required for ELB pings to work,
+# see https://github.com/parklab/refinery-platform/issues/1239)
+
+# Not checking for exceptions: if we can't get EC2 instance
+# metadata, something horrible is wrong.
+PRIVATE_IP = requests.get(
+  "http://169.254.169.254/latest/meta-data/local-ipv4", timeout=1.0).text
+
+ALLOWED_HOSTS.append(PRIVATE_IP)
+
 EMAIL_BACKEND = 'django_smtp_ssl.SSLEmailBackend'
 EMAIL_HOST_USER = get_setting('EMAIL_HOST_USER')
 EMAIL_HOST_PASSWORD = get_setting('EMAIL_HOST_PASSWORD')


### PR DESCRIPTION
on AWS.

Notes

- Only works on AWS. That's okay, because it's in a settings file that is only used on AWS;
- Only needed when `Debug=False`, so only needed in `aws.py` not `awsdev.py`