### PR TITLE
ADMIN was not being used consistently in the templates

### DIFF
--- a/refinery/core/context_processors.py
+++ b/refinery/core/context_processors.py
@@ -24,7 +24,7 @@ def extra_context(context):
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     """
     return {
-        "ADMINS": settings.ADMINS[0][1],
+        "ADMIN_EMAIL": settings.ADMINS[0][1],
         "CURRENT_COMMIT": settings.CURRENT_COMMIT,
         "DEBUG": settings.DEBUG,
         "REFINERY_CSS": settings.REFINERY_CSS,

--- a/refinery/templates/401.html
+++ b/refinery/templates/401.html
@@ -21,7 +21,7 @@
 		<p>
 			We are re sorry, but you need to be logged in to perform this action.<br /><br />
 			If you believe you reached this page in error, please contact your
-            <a href='mailto:{{ADMINS.0.1}}?Subject=Refinery%20Error' target='_top'>System Administrator</a>.
+            <a href='mailto:{{ADMIN_EMAIL}}?Subject=Refinery%20Error' target='_top'>System Administrator</a>.
 		</p>
 	</div>
 </div>

--- a/refinery/templates/403.html
+++ b/refinery/templates/403.html
@@ -23,7 +23,7 @@
 			If you would like to {{msg}}, click <a href="{% url 'django.contrib.auth.views.logout' %}?next={% url 'django.contrib.auth.views.login' %}?next={% if request.path %}{{ request.path|safe }}{% else %}{% url 'home' %}{% endif %}">here</a> to log out and log in again as a different user.
 			<br /><br />
 			If you believe you reached this page in error, please contact your
-            <a href='mailto:{{ADMINS.0.1}}?Subject=Refinery%20Error' target='_top'>System Administrator</a>.
+            <a href='mailto:{{ADMIN_EMAIL}}?Subject=Refinery%20Error' target='_top'>System Administrator</a>.
 		</p>
 	</div>
 </div>

--- a/refinery/templates/404.html
+++ b/refinery/templates/404.html
@@ -21,7 +21,7 @@
 		<p>
 			We're sorry, but we couldn't find this page.  You may have used an outdated link or typed in the URL incorrectly.<br /><br />
 			If you think you reached this page in error, then please contact
-            your <a href='mailto:{{ADMINS.0.1}}?Subject=Refinery%20Error' target='_top'>System Administrator</a>.
+            your <a href='mailto:{{ADMIN_EMAIL}}?Subject=Refinery%20Error' target='_top'>System Administrator</a>.
 		</p>
 	</div>
 </div>

--- a/refinery/templates/500.html
+++ b/refinery/templates/500.html
@@ -20,7 +20,7 @@
 		</div>
 		<p>
 			The server encountered an internal error or misconfiguration and was unable to complete your request.<br /><br />
-			Please contact your <a href='mailto:{{ADMINS.0.1}}?Subject=Refinery%20Error' target='_top'>System Administrator</a> if this is a recurring problem and describe
+			Please contact your <a href='mailto:{{ADMIN_EMAIL}}?Subject=Refinery%20Error' target='_top'>System Administrator</a> if this is a recurring problem and describe
             anything you might have done that may have caused the error.
 		</p>
 	</div>

--- a/refinery/templates/base.html
+++ b/refinery/templates/base.html
@@ -29,7 +29,7 @@
       debug: {{ DEBUG|yesno:"true,false,undefined" }},
       userId: '{{ user.id }}',
       userName: '{{ user.username }}',
-      admins: '{{ ADMINS|safe }}',
+      admins: '{{ ADMIN_EMAIL|safe }}',
       repositoryMode: {{ REFINERY_REPOSITORY_MODE|yesno:"true,false,undefined" }},
       solrSynonymSearch: {{ SOLR_SYNONYM_SEARCH|lower }}
     };
@@ -272,7 +272,7 @@
 
     var username = '{{ user.username }}';
     var user_id = '{{ user.id }}';
-    var admins = '{{ ADMINS|safe }}';
+    var admins = '{{ ADMIN_EMAIL|safe }}';
     if (username === 'None' || user_id === 'None') {
         username = undefined;
         user_id = undefined;

--- a/refinery/templates/registration/registration_complete.html
+++ b/refinery/templates/registration/registration_complete.html
@@ -24,7 +24,7 @@
             <br><br>
             We generally attempt to approve accounts within 2 business days.
             If you do not hear from us within that time frame, please
-            contact the Administrator: <a href="mailto:{{ ADMINS }}?Subject=Regarding my account activation" target="_top">{{ ADMINS }}</a> mentioning your
+            contact the Administrator: <a href="mailto:{{ ADMIN_EMAIL }}?Subject=Regarding my account activation" target="_top">{{ ADMIN_EMAIL }}</a> mentioning your
             username.
 		</p>
 


### PR DESCRIPTION
Rather than say one usage or the other is correct, introduce a new, less ambiguous name.
When started in prod mode, the 404 page now has an email.

Fix #1340