### PR TITLE
Mccalluc/travis fast fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,10 @@ before_script:
   - bower install --config.interactive=false
   - cd ../
 script:
+  - this-should-not-cause-fail
+  - set -e
+  - but-this-should-fail
+
   - flake8 --exclude=migrations,ui ..
 
   - echo 'travis_fold:start:grunt'

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_script:
   - bower install --config.interactive=false
   - cd ../
 script:
-  - set -e
+  - set -e # Any error will cause travis to exit early and report a failure.
 
   - flake8 --exclude=migrations,ui ..
 
@@ -61,7 +61,7 @@ script:
   - coverage run manage.py test
   - echo 'travis_fold:end:django-tests'
 
-  - set +e
+  - set +e # Currently, codecov does not always exit with 0, but that should not cause travis to fail.
 after_success:
   - codecov
   - npm run codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ script:
   - echo 'travis_fold:start:django-tests'
   - coverage run manage.py test
   - echo 'travis_fold:end:django-tests'
+
+  - set +e
 after_success:
   - codecov
   - npm run codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,7 @@ before_script:
   - bower install --config.interactive=false
   - cd ../
 script:
-  - this-should-not-cause-fail
   - set -e
-  - but-this-should-fail
 
   - flake8 --exclude=migrations,ui ..
 


### PR DESCRIPTION
- The first commit fails in the expected manner
- The second commit gets through all the tests, and then fails on codecov:
```
$ npm run codecov
ERR! Error: ENOENT, open '/home/travis/build/parklab/refinery-platform/refinery/package.json'
```
Looking at an earlier travis run which did complete successfully, I see the same error near the end of the full log, but it kept on going: https://travis-ci.org/parklab/refinery-platform/builds/162217766 for example. 
- In the last commit, I add `set +e` at the end of the script section, and it passes ... but maybe we do want to know about errors after the script?

@jkmarx : Does this look ok?