### PR TITLE
Fix caching bug where # of Analyses run on a DataSet wasn't updated

### DIFF
--- a/refinery/ui/source/js/dashboard/controllers/analysis-deletion.js
+++ b/refinery/ui/source/js/dashboard/controllers/analysis-deletion.js
@@ -8,6 +8,7 @@ function AnalysisDeleteCtrl (
   config,
   analysis,
   analyses,
+  dataSets,
   analysesReloadService,
   isOwner,
   dashboardDataSetsReloadService
@@ -17,6 +18,7 @@ function AnalysisDeleteCtrl (
   this.config = config;
   this.analysis = analysis;
   this.analyses = analyses;
+  this.dataSets = dataSets;
   this.$uibModalInstance = $uibModalInstance;
   this.deletionService = deletionService;
   this.analysesReloadService = analysesReloadService;
@@ -54,6 +56,7 @@ AnalysisDeleteCtrl.prototype.delete = function () {
       that.deletionMessage = response.data;
       that.isDeleting = false;
       that.deleteSuccessful = true;
+      that.dataSets.newOrCachedCache(undefined, true);
       that.dashboardDataSetsReloadService.reload(true);
       that.analyses.newOrCachedCache(undefined, true);
       that.analysesReloadService.reload();
@@ -75,6 +78,7 @@ angular
     'config',
     'analysis',
     'analyses',
+    'dataSets',
     'analysesReloadService',
     'isOwner',
     'dashboardDataSetsReloadService',

--- a/refinery/ui/source/js/dashboard/controllers/dashboard.js
+++ b/refinery/ui/source/js/dashboard/controllers/dashboard.js
@@ -1659,6 +1659,7 @@ DashboardCtrl.prototype.openAnalysisDeleteModal = function (analysis) {
       },
       analysis: analysis,
       analyses: this.analyses,
+      dataSets: this.dataSets,
       analysesReloadService: this.dashboardAnalysesReloadService,
       isOwner: analysis.is_owner
     }

--- a/refinery/ui/source/js/dashboard/controllers/dataset-deletion.js
+++ b/refinery/ui/source/js/dashboard/controllers/dataset-deletion.js
@@ -55,6 +55,7 @@ DataSetDeleteCtrl.prototype.delete = function () {
       that.deletionMessage = response.data;
       that.isDeleting = false;
       that.deleteSuccessful = true;
+      that.dataSets.newOrCachedCache(undefined, true);
       that.dashboardDataSetsReloadService.reload(true);
       that.analyses.newOrCachedCache(undefined, true);
       that.analysesReloadService.reload();


### PR DESCRIPTION
See the proper behavior below
![oct-17-2016 12-48-51](https://cloud.githubusercontent.com/assets/5629547/19446741/2772f572-9468-11e6-8ab7-6167e5ad868d.gif)
:

