### PR TITLE
Scottx611x/resolve manual fake issue

### DIFF
--- a/refinery/annotation_server/fixtures/initial_data.json
+++ b/refinery/annotation_server/fixtures/initial_data.json
@@ -1,786 +1,763 @@
 [
 {
-  "pk": 1, 
-  "model": "annotation_server.taxon", 
+  "pk": 1,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "includes", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "includes",
     "name": "LK3 transgenic mice"
   }
 },
 {
-  "pk": 2, 
-  "model": "annotation_server.taxon", 
+  "pk": 2,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "misnomer", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "misnomer",
     "name": "Mus muscaris"
   }
 },
 {
-  "pk": 3, 
-  "model": "annotation_server.taxon", 
+  "pk": 3,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "scientific name", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "scientific name",
     "name": "Mus musculus"
   }
 },
 {
-  "pk": 4, 
-  "model": "annotation_server.taxon", 
+  "pk": 4,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "Mus musculus", 
-    "type": "abbreviation", 
+    "taxon_id": 10090,
+    "unique_name": "Mus musculus",
+    "type": "abbreviation",
     "name": "M. musculus"
   }
 },
 {
-  "pk": 5, 
-  "model": "annotation_server.taxon", 
+  "pk": 5,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "authority", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "authority",
     "name": "Mus musculus Linnaeus, 1758"
   }
 },
 {
-  "pk": 6, 
-  "model": "annotation_server.taxon", 
+  "pk": 6,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "includes", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "includes",
     "name": "Mus sp. 129SV"
   }
 },
 {
-  "pk": 7, 
-  "model": "annotation_server.taxon", 
+  "pk": 7,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "genbank common name", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "genbank common name",
     "name": "house mouse"
   }
 },
 {
-  "pk": 8, 
-  "model": "annotation_server.taxon", 
+  "pk": 8,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "misspelling", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "misspelling",
     "name": "mice C57BL/6xCBA/CaJ hybrid"
   }
 },
 {
-  "pk": 9, 
-  "model": "annotation_server.taxon", 
+  "pk": 9,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "common name", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "common name",
     "name": "mouse"
   }
 },
 {
-  "pk": 10, 
-  "model": "annotation_server.taxon", 
+  "pk": 10,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "includes", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "includes",
     "name": "nude mice"
   }
 },
 {
-  "pk": 11, 
-  "model": "annotation_server.taxon", 
+  "pk": 11,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 10090, 
-    "unique_name": "", 
-    "type": "includes", 
+    "taxon_id": 10090,
+    "unique_name": "",
+    "type": "includes",
     "name": "transgenic mice"
   }
 },
 {
-  "pk": 12, 
-  "model": "annotation_server.taxon", 
+  "pk": 12,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 6239, 
-    "unique_name": "", 
-    "type": "scientific name", 
+    "taxon_id": 6239,
+    "unique_name": "",
+    "type": "scientific name",
     "name": "Caenorhabditis elegans"
   }
 },
 {
-  "pk": 13, 
-  "model": "annotation_server.taxon", 
+  "pk": 13,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 6239, 
-    "unique_name": "Caenorhabditis elegans", 
-    "type": "abbreviation", 
+    "taxon_id": 6239,
+    "unique_name": "Caenorhabditis elegans",
+    "type": "abbreviation",
     "name": "C. elegans"
   }
 },
 {
-  "pk": 14, 
-  "model": "annotation_server.taxon", 
+  "pk": 14,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 6239, 
-    "unique_name": "", 
-    "type": "authority", 
+    "taxon_id": 6239,
+    "unique_name": "",
+    "type": "authority",
     "name": "Caenorhabditis elegans (Maupas, 1900)"
   }
 },
 {
-  "pk": 15, 
-  "model": "annotation_server.taxon", 
+  "pk": 15,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 6239, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 6239,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Rhabditis elegans"
   }
 },
 {
-  "pk": 16, 
-  "model": "annotation_server.taxon", 
+  "pk": 16,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 6239, 
-    "unique_name": "", 
-    "type": "authority", 
+    "taxon_id": 6239,
+    "unique_name": "",
+    "type": "authority",
     "name": "Rhabditis elegans Maupas, 1900"
   }
 },
 {
-  "pk": 17, 
-  "model": "annotation_server.taxon", 
+  "pk": 17,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 6239, 
-    "unique_name": "nematode <Caenorhabditis elegans>", 
-    "type": "common name", 
+    "taxon_id": 6239,
+    "unique_name": "nematode <Caenorhabditis elegans>",
+    "type": "common name",
     "name": "nematode"
   }
 },
 {
-  "pk": 18, 
-  "model": "annotation_server.taxon", 
+  "pk": 18,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7227, 
-    "unique_name": "", 
-    "type": "misspelling", 
+    "taxon_id": 7227,
+    "unique_name": "",
+    "type": "misspelling",
     "name": "Drosophila melangaster"
   }
 },
 {
-  "pk": 19, 
-  "model": "annotation_server.taxon", 
+  "pk": 19,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7227, 
-    "unique_name": "", 
-    "type": "scientific name", 
+    "taxon_id": 7227,
+    "unique_name": "",
+    "type": "scientific name",
     "name": "Drosophila melanogaster"
   }
 },
 {
-  "pk": 20, 
-  "model": "annotation_server.taxon", 
+  "pk": 20,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7227, 
-    "unique_name": "Drosophila melanogaster", 
-    "type": "abbreviation", 
+    "taxon_id": 7227,
+    "unique_name": "Drosophila melanogaster",
+    "type": "abbreviation",
     "name": "D. melanogaster"
   }
 },
 {
-  "pk": 21, 
-  "model": "annotation_server.taxon", 
+  "pk": 21,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7227, 
-    "unique_name": "", 
-    "type": "authority", 
+    "taxon_id": 7227,
+    "unique_name": "",
+    "type": "authority",
     "name": "Drosophila melanogaster Meigen, 1830"
   }
 },
 {
-  "pk": 22, 
-  "model": "annotation_server.taxon", 
+  "pk": 22,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7227, 
-    "unique_name": "", 
-    "type": "genbank common name", 
+    "taxon_id": 7227,
+    "unique_name": "",
+    "type": "genbank common name",
     "name": "fruit fly"
   }
 },
 {
-  "pk": 23, 
-  "model": "annotation_server.taxon", 
+  "pk": 23,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 9606, 
-    "unique_name": "", 
-    "type": "scientific name", 
+    "taxon_id": 9606,
+    "unique_name": "",
+    "type": "scientific name",
     "name": "Homo sapiens"
   }
 },
 {
-  "pk": 24, 
-  "model": "annotation_server.taxon", 
+  "pk": 24,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 9606, 
-    "unique_name": "Homo sapiens", 
-    "type": "abbreviation", 
+    "taxon_id": 9606,
+    "unique_name": "Homo sapiens",
+    "type": "abbreviation",
     "name": "H. sapiens"
   }
 },
 {
-  "pk": 25, 
-  "model": "annotation_server.taxon", 
+  "pk": 25,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 9606, 
-    "unique_name": "", 
-    "type": "authority", 
+    "taxon_id": 9606,
+    "unique_name": "",
+    "type": "authority",
     "name": "Homo sapiens Linnaeus, 1758"
   }
 },
 {
-  "pk": 26, 
-  "model": "annotation_server.taxon", 
+  "pk": 26,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 9606, 
-    "unique_name": "", 
-    "type": "genbank common name", 
+    "taxon_id": 9606,
+    "unique_name": "",
+    "type": "genbank common name",
     "name": "human"
   }
 },
 {
-  "pk": 27, 
-  "model": "annotation_server.taxon", 
+  "pk": 27,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 9606, 
-    "unique_name": "", 
-    "type": "common name", 
+    "taxon_id": 9606,
+    "unique_name": "",
+    "type": "common name",
     "name": "man"
   }
 },
 {
-  "pk": 28, 
-  "model": "annotation_server.taxon", 
+  "pk": 28,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 4896, 
-    "unique_name": "", 
-    "type": "common name", 
+    "taxon_id": 4896,
+    "unique_name": "",
+    "type": "common name",
     "name": "fission yeast"
   }
 },
 {
-  "pk": 29, 
-  "model": "annotation_server.taxon", 
+  "pk": 29,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 4896, 
-    "unique_name": "", 
-    "type": "scientifc name", 
+    "taxon_id": 4896,
+    "unique_name": "",
+    "type": "scientifc name",
     "name": "Schizosaccharomyces pombe"
   }
 },
 {
-  "pk": 30, 
-  "model": "annotation_server.taxon", 
+  "pk": 30,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 4896, 
-    "unique_name": "Schizosaccharomyces pombe", 
-    "type": "abbreviation name", 
+    "taxon_id": 4896,
+    "unique_name": "Schizosaccharomyces pombe",
+    "type": "abbreviation name",
     "name": "S. pombe"
   }
 },
 {
-  "pk": 31, 
-  "model": "annotation_server.taxon", 
+  "pk": 31,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "scientific name", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "scientific name",
     "name": "Danio rerio"
   }
 },
 {
-  "pk": 32, 
-  "model": "annotation_server.taxon", 
+  "pk": 32,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "Danio rerio", 
-    "type": "abbreviation", 
+    "taxon_id": 7955,
+    "unique_name": "Danio rerio",
+    "type": "abbreviation",
     "name": "D. rerio"
   }
 },
 {
-  "pk": 33, 
-  "model": "annotation_server.taxon", 
+  "pk": 33,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "zebra fish <Danio rerio>", 
-    "type": "common name", 
+    "taxon_id": 7955,
+    "unique_name": "zebra fish <Danio rerio>",
+    "type": "common name",
     "name": "zebra fish"
   }
 },
 {
-  "pk": 34, 
-  "model": "annotation_server.taxon", 
+  "pk": 34,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "misspelling", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "misspelling",
     "name": "Brachidanio rerio"
   }
 },
 {
-  "pk": 35, 
-  "model": "annotation_server.taxon", 
+  "pk": 35,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Brachydanio rerio"
   }
 },
 {
-  "pk": 36, 
-  "model": "annotation_server.taxon", 
+  "pk": 36,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Brachydanio rerio frankei"
   }
 },
 {
-  "pk": 37, 
-  "model": "annotation_server.taxon", 
+  "pk": 37,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Cyprinus rerio"
   }
 },
 {
-  "pk": 38, 
-  "model": "annotation_server.taxon", 
+  "pk": 38,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Cyprinus rerio Hamilton, 1822"
   }
 },
 {
-  "pk": 39, 
-  "model": "annotation_server.taxon", 
+  "pk": 39,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Danio frankei"
   }
 },
 {
-  "pk": 40, 
-  "model": "annotation_server.taxon", 
+  "pk": 40,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Danio rerio (Hamilton, 1822)"
   }
 },
 {
-  "pk": 41, 
-  "model": "annotation_server.taxon", 
+  "pk": 41,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "synonym", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "synonym",
     "name": "Danio rerio frankei"
   }
 },
 {
-  "pk": 42, 
-  "model": "annotation_server.taxon", 
+  "pk": 42,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "common name", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "common name",
     "name": "leopard danio"
   }
 },
 {
-  "pk": 43, 
-  "model": "annotation_server.taxon", 
+  "pk": 43,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "common name", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "common name",
     "name": "zebra danio"
   }
 },
 {
-  "pk": 44, 
-  "model": "annotation_server.taxon", 
+  "pk": 44,
+  "model": "annotation_server.taxon",
   "fields": {
-    "taxon_id": 7955, 
-    "unique_name": "", 
-    "type": "genbank common name", 
+    "taxon_id": 7955,
+    "unique_name": "",
+    "type": "genbank common name",
     "name": "zebrafish"
   }
 },
 {
-  "pk": 1, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 1,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "GRCh37 Genome Reference Consortium Human Reference 37 (GCA_000001405.1)", 
-    "name": "hg19", 
-    "default_build": true, 
-    "html_path": "/gbdb/hg19/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 23, 
+    "available": true,
+    "source_name": "GRCh37 Genome Reference Consortium Human Reference 37 (GCA_000001405.1)",
+    "name": "hg19",
+    "default_build": true,
+    "html_path": "/gbdb/hg19/html/description.html",
+    "affiliation": "UCSC",
+    "species": 23,
     "description": "Feb. 2009 (GRCh37/hg19)"
   }
 },
 {
-  "pk": 2, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 2,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 1, 
-    "source_name": null, 
-    "name": "Genome Reference Consortium GRCh37", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "Genome Reference Consortium", 
-    "species": 23, 
+    "available": true,
+    "source_name": null,
+    "name": "Genome Reference Consortium GRCh37",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "Genome Reference Consortium",
+    "species": 23,
     "description": "Feb. 2009"
   }
 },
 {
-  "pk": 3, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 3,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "NCBI Build 36.1", 
-    "name": "hg18", 
-    "default_build": false, 
-    "html_path": "/gbdb/hg18/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 23, 
+    "available": true,
+    "source_name": "NCBI Build 36.1",
+    "name": "hg18",
+    "default_build": false,
+    "html_path": "/gbdb/hg18/html/description.html",
+    "affiliation": "UCSC",
+    "species": 23,
     "description": "Mar. 2006 (NCBI36/hg18)"
   }
 },
 {
-  "pk": 4, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 4,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 3, 
-    "source_name": null, 
-    "name": "NCBI Build 36.1", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "NCBI", 
-    "species": 23, 
+    "available": true,
+    "source_name": null,
+    "name": "NCBI Build 36.1",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "NCBI",
+    "species": 23,
     "description": "Mar. 2006"
   }
 },
 {
-  "pk": 5, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 5,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "NCBI Build 36", 
-    "name": "mm8", 
-    "default_build": false, 
-    "html_path": "/gbdb/mm8/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 3, 
+    "available": true,
+    "source_name": "NCBI Build 36",
+    "name": "mm8",
+    "default_build": false,
+    "html_path": "/gbdb/mm8/html/description.html",
+    "affiliation": "UCSC",
+    "species": 3,
     "description": "Feb. 2006 (NCBI36/mm8)"
   }
 },
 {
-  "pk": 6, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 6,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 5, 
-    "source_name": null, 
-    "name": "NCBI Build 36", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "NCBI", 
-    "species": 3, 
+    "available": true,
+    "source_name": null,
+    "name": "NCBI Build 36",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "NCBI",
+    "species": 3,
     "description": "Feb. 2006"
   }
 },
 {
-  "pk": 7, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 7,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "NCBI Build 37", 
-    "name": "mm9", 
-    "default_build": true, 
-    "html_path": "/gbdb/mm9/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 3, 
+    "available": true,
+    "source_name": "NCBI Build 37",
+    "name": "mm9",
+    "default_build": true,
+    "html_path": "/gbdb/mm9/html/description.html",
+    "affiliation": "UCSC",
+    "species": 3,
     "description": "July 2007 (NCBI37/mm9)"
   }
 },
 {
-  "pk": 8, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 8,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 7, 
-    "source_name": null, 
-    "name": "NCBI Build 37", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "NCBI", 
-    "species": 3, 
+    "available": true,
+    "source_name": null,
+    "name": "NCBI Build 37",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "NCBI",
+    "species": 3,
     "description": "Jul. 2007"
   }
 },
 {
-  "pk": 9, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 9,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "Genome Reference Consortium Mouse Build 38 (GCA_000001635.2)", 
-    "name": "mm10", 
-    "default_build": false, 
-    "html_path": "/gbdb/mm10/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 3, 
+    "available": true,
+    "source_name": "Genome Reference Consortium Mouse Build 38 (GCA_000001635.2)",
+    "name": "mm10",
+    "default_build": false,
+    "html_path": "/gbdb/mm10/html/description.html",
+    "affiliation": "UCSC",
+    "species": 3,
     "description": "Dec. 2011 (GRCm38/mm10)"
   }
 },
 {
-  "pk": 10, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 10,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 9, 
-    "source_name": null, 
-    "name": "Genome Reference Consortium GRCm38", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "Genome Reference Consortium", 
-    "species": 3, 
+    "available": true,
+    "source_name": null,
+    "name": "Genome Reference Consortium GRCm38",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "Genome Reference Consortium",
+    "species": 3,
     "description": "Dec. 2011"
   }
 },
 {
-  "pk": 11, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 11,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "BDGP Release 5", 
-    "name": "dm3", 
-    "default_build": true, 
-    "html_path": "/gbdb/dm3/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 19, 
+    "available": true,
+    "source_name": "BDGP Release 5",
+    "name": "dm3",
+    "default_build": true,
+    "html_path": "/gbdb/dm3/html/description.html",
+    "affiliation": "UCSC",
+    "species": 19,
     "description": "Apr. 2006 (BDGP R5/dm3)"
   }
 },
 {
-  "pk": 12, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 12,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 11, 
-    "source_name": null, 
-    "name": "BDGP Release 5", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "BDGP", 
-    "species": 19, 
+    "available": true,
+    "source_name": null,
+    "name": "BDGP Release 5",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "BDGP",
+    "species": 19,
     "description": "Apr. 2006"
   }
 },
 {
-  "pk": 13, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 13,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "BDGP v. 4 / DHGP v. 3.2", 
-    "name": "dm2", 
-    "default_build": false, 
-    "html_path": "/gbdb/dm2/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 19, 
+    "available": true,
+    "source_name": "BDGP v. 4 / DHGP v. 3.2",
+    "name": "dm2",
+    "default_build": false,
+    "html_path": "/gbdb/dm2/html/description.html",
+    "affiliation": "UCSC",
+    "species": 19,
     "description": "Apr. 2004 (BDGP R4/dm2)"
   }
 },
 {
-  "pk": 14, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 14,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 13, 
-    "source_name": null, 
-    "name": "BDGP Release 4", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "BDGP", 
-    "species": 19, 
+    "available": true,
+    "source_name": null,
+    "name": "BDGP Release 4",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "BDGP",
+    "species": 19,
     "description": "Apr. 2004"
   }
 },
 {
-  "pk": 15, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 15,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "BDGP v. 3", 
-    "name": "dm1", 
-    "default_build": false, 
-    "html_path": "/gbdb/dm1/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 19, 
+    "available": true,
+    "source_name": "BDGP v. 3",
+    "name": "dm1",
+    "default_build": false,
+    "html_path": "/gbdb/dm1/html/description.html",
+    "affiliation": "UCSC",
+    "species": 19,
     "description": "Jan. 2003 (BDGP R3/dm1)"
   }
 },
 {
-  "pk": 16, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 16,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 15, 
-    "source_name": null, 
-    "name": "BDGP Release 3", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "BDGP", 
-    "species": 19, 
+    "available": true,
+    "source_name": null,
+    "name": "BDGP Release 3",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "BDGP",
+    "species": 19,
     "description": "Jan. 2003"
   }
 },
 {
-  "pk": 17, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 17,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "Washington University School of Medicine GSC and Sanger Institute WS220", 
-    "name": "ce10", 
-    "default_build": false, 
-    "html_path": "/gbdb/ce10/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 12, 
+    "available": true,
+    "source_name": "Washington University School of Medicine GSC and Sanger Institute WS220",
+    "name": "ce10",
+    "default_build": false,
+    "html_path": "/gbdb/ce10/html/description.html",
+    "affiliation": "UCSC",
+    "species": 12,
     "description": "Oct. 2010 (WS220/ce10)"
   }
 },
 {
-  "pk": 18, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 18,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 17, 
-    "source_name": null, 
-    "name": "WormBase v. WS220", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "WormBase", 
-    "species": 12, 
+    "available": true,
+    "source_name": null,
+    "name": "WormBase v. WS220",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "WormBase",
+    "species": 12,
     "description": "Oct. 2010"
   }
 },
 {
-  "pk": 19, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 19,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": "Washington University School of Medicine GSC and Sanger Institute WS190", 
-    "name": "ce6", 
-    "default_build": true, 
-    "html_path": "/gbdb/ce6/html/description.html", 
-    "affiliation": "UCSC", 
-    "species": 12, 
+    "available": true,
+    "source_name": "Washington University School of Medicine GSC and Sanger Institute WS190",
+    "name": "ce6",
+    "default_build": true,
+    "html_path": "/gbdb/ce6/html/description.html",
+    "affiliation": "UCSC",
+    "species": 12,
     "description": "May 2008 (WS190/ce6)"
   }
 },
 {
-  "pk": 20, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 20,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 19, 
-    "source_name": null, 
-    "name": "WormBase v. WS190", 
-    "default_build": false, 
-    "html_path": null, 
-    "affiliation": "WormBase", 
-    "species": 12, 
+    "available": true,
+    "source_name": null,
+    "name": "WormBase v. WS190",
+    "default_build": false,
+    "html_path": null,
+    "affiliation": "WormBase",
+    "species": 12,
     "description": "May 2008"
   }
 },
 {
-  "pk": 21, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 21,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": null, 
-    "source_name": null, 
-    "name": "spombe_1.55", 
-    "default_build": true, 
-    "html_path": null, 
-    "affiliation": "", 
-    "species": 29, 
+    "available": true,
+    "source_name": null,
+    "name": "spombe_1.55",
+    "default_build": true,
+    "html_path": null,
+    "affiliation": "",
+    "species": 29,
     "description": "Added manually by Nils Gehlenborg on 15 March 2013."
   }
 },
 {
-  "pk": 22, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 22,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": false, 
-    "ucsc_equivalent": null, 
-    "source_name": "Sanger Institute", 
-    "name": "danRer7", 
-    "default_build": true, 
-    "html_path": "", 
-    "affiliation": "UCSC", 
-    "species": 31, 
+    "available": false,
+    "source_name": "Sanger Institute",
+    "name": "danRer7",
+    "default_build": true,
+    "html_path": "",
+    "affiliation": "UCSC",
+    "species": 31,
     "description": "Jul. 2010 (Zv9/danRer7)"
   }
 },
 {
-  "pk": 23, 
-  "model": "annotation_server.genomebuild", 
+  "pk": 23,
+  "model": "annotation_server.genomebuild",
   "fields": {
-    "available": true, 
-    "ucsc_equivalent": 22, 
-    "source_name": "", 
-    "name": "Zv9", 
-    "default_build": false, 
-    "html_path": "", 
-    "affiliation": "Sanger Institute", 
-    "species": 31, 
+    "available": true,
+    "source_name": "",
+    "name": "Zv9",
+    "default_build": false,
+    "html_path": "",
+    "affiliation": "Sanger Institute",
+    "species": 31,
     "description": "Jul. 2010"
   }
 }

--- a/refinery/annotation_server/migrations/0002_auto__del_dm3_chrominfo__del_hg19_sequence__del_hg19_mappabilityempiri.py
+++ b/refinery/annotation_server/migrations/0002_auto__del_dm3_chrominfo__del_hg19_sequence__del_hg19_mappabilityempiri.py
@@ -1,0 +1,793 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting model 'dm3_ChromInfo'
+        db.delete_table(u'annotation_server_dm3_chrominfo')
+
+        # Deleting model 'hg19_Sequence'
+        db.delete_table(u'annotation_server_hg19_sequence')
+
+        # Deleting model 'hg19_MappabilityEmpirial'
+        db.delete_table(u'annotation_server_hg19_mappabilityempirial')
+
+        # Deleting model 'hg19_GapRegions'
+        db.delete_table(u'annotation_server_hg19_gapregions')
+
+        # Deleting model 'hg19_CytoBand'
+        db.delete_table(u'annotation_server_hg19_cytoband')
+
+        # Deleting model 'ce10_GC'
+        db.delete_table(u'annotation_server_ce10_gc')
+
+        # Deleting model 'hg19_GC'
+        db.delete_table(u'annotation_server_hg19_gc')
+
+        # Deleting model 'ce10_MappabilityEmpirial'
+        db.delete_table(u'annotation_server_ce10_mappabilityempirial')
+
+        # Deleting model 'hg19_Conservation'
+        db.delete_table(u'annotation_server_hg19_conservation')
+
+        # Deleting model 'dm3_Conservation'
+        db.delete_table(u'annotation_server_dm3_conservation')
+
+        # Deleting model 'ce10_EnsGene'
+        db.delete_table(u'annotation_server_ce10_ensgene')
+
+        # Deleting model 'ce10_CytoBand'
+        db.delete_table(u'annotation_server_ce10_cytoband')
+
+        # Deleting model 'dm3_CytoBand'
+        db.delete_table(u'annotation_server_dm3_cytoband')
+
+        # Deleting model 'dm3_Sequence'
+        db.delete_table(u'annotation_server_dm3_sequence')
+
+        # Deleting model 'hg19_ChromInfo'
+        db.delete_table(u'annotation_server_hg19_chrominfo')
+
+        # Deleting model 'dm3_MappabilityEmpirial'
+        db.delete_table(u'annotation_server_dm3_mappabilityempirial')
+
+        # Deleting model 'ce10_Sequence'
+        db.delete_table(u'annotation_server_ce10_sequence')
+
+        # Deleting model 'dm3_GC'
+        db.delete_table(u'annotation_server_dm3_gc')
+
+        # Deleting model 'dm3_EnsGene'
+        db.delete_table(u'annotation_server_dm3_ensgene')
+
+        # Deleting model 'dm3_GapRegions'
+        db.delete_table(u'annotation_server_dm3_gapregions')
+
+        # Deleting model 'hg19_MappabilityTheoretical'
+        db.delete_table(u'annotation_server_hg19_mappabilitytheoretical')
+
+        # Deleting model 'ce10_ChromInfo'
+        db.delete_table(u'annotation_server_ce10_chrominfo')
+
+        # Deleting model 'hg19_EnsGene'
+        db.delete_table(u'annotation_server_hg19_ensgene')
+
+        # Deleting model 'ce10_Conservation'
+        db.delete_table(u'annotation_server_ce10_conservation')
+
+        # Adding model 'EmpiricalMappability'
+        db.create_table(u'annotation_server_empiricalmappability', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('score', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('thickStart', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('thickEnd', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('itemRgb', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('blockCount', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('blockSizes', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('blockStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+        ))
+        db.send_create_signal(u'annotation_server', ['EmpiricalMappability'])
+
+        # Adding model 'GCContent'
+        db.create_table(u'annotation_server_gccontent', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+        ))
+        db.send_create_signal(u'annotation_server', ['GCContent'])
+
+        # Adding model 'Gene'
+        db.create_table(u'annotation_server_gene', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('txStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('txEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('cdsStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('cdsEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonCount', self.gf('django.db.models.fields.IntegerField')()),
+            ('exonStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+            ('exonEnds', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+            ('score', self.gf('django.db.models.fields.IntegerField')()),
+            ('name2', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('cdsStartStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('cdsEndStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('exonFrames', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+        ))
+        db.send_create_signal(u'annotation_server', ['Gene'])
+
+        # Adding model 'GapRegionFile'
+        db.create_table(u'annotation_server_gapregionfile', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('ix', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('n', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('size', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('type', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('bridge', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal(u'annotation_server', ['GapRegionFile'])
+
+        # Adding model 'ConservationTrack'
+        db.create_table(u'annotation_server_conservationtrack', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+        ))
+        db.send_create_signal(u'annotation_server', ['ConservationTrack'])
+
+        # Adding model 'ChromInfo'
+        db.create_table(u'annotation_server_chrominfo', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('size', self.gf('django.db.models.fields.IntegerField')()),
+            ('fileName', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal(u'annotation_server', ['ChromInfo'])
+
+        # Adding model 'TheoreticalMappability'
+        db.create_table(u'annotation_server_theoreticalmappability', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('score', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('thickStart', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('thickEnd', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('itemRgb', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('blockCount', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('blockSizes', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('blockStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+        ))
+        db.send_create_signal(u'annotation_server', ['TheoreticalMappability'])
+
+        # Adding model 'CytoBand'
+        db.create_table(u'annotation_server_cytoband', (
+            (u'id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('genomebuild', self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('gieStain', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal(u'annotation_server', ['CytoBand'])
+
+        # Adding field 'dm3_FlyBase.genomebuild'
+        db.add_column(u'annotation_server_dm3_flybase', 'genomebuild',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True),
+                      keep_default=False)
+
+        # Adding field 'hg19_GenCode.genomebuild'
+        db.add_column(u'annotation_server_hg19_gencode', 'genomebuild',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True),
+                      keep_default=False)
+
+        # Adding field 'ce10_WormBase.genomebuild'
+        db.add_column(u'annotation_server_ce10_wormbase', 'genomebuild',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True),
+                      keep_default=False)
+
+        # Deleting field 'WigDescription.genome_build'
+        db.delete_column(u'annotation_server_wigdescription', 'genome_build')
+
+        # Adding field 'WigDescription.genomebuild'
+        db.add_column(u'annotation_server_wigdescription', 'genomebuild',
+                      self.gf('django.db.models.fields.related.ForeignKey')(default=None, to=orm['annotation_server.GenomeBuild'], null=True),
+                      keep_default=False)
+
+        # Deleting field 'GenomeBuild.ucsc_equivalent'
+        db.delete_column(u'annotation_server_genomebuild', 'ucsc_equivalent_id')
+
+
+    def backwards(self, orm):
+        # Adding model 'dm3_ChromInfo'
+        db.create_table(u'annotation_server_dm3_chrominfo', (
+            ('size', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('fileName', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_ChromInfo'])
+
+        # Adding model 'hg19_Sequence'
+        db.create_table(u'annotation_server_hg19_sequence', (
+            ('seq_id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(default='+', max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True, db_index=True)),
+            ('seq', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_Sequence'])
+
+        # Adding model 'hg19_MappabilityEmpirial'
+        db.create_table(u'annotation_server_hg19_mappabilityempirial', (
+            ('blockStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('blockSizes', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('score', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('blockCount', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('itemRgb', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('thickEnd', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('thickStart', self.gf('django.db.models.fields.IntegerField')(null=True)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_MappabilityEmpirial'])
+
+        # Adding model 'hg19_GapRegions'
+        db.create_table(u'annotation_server_hg19_gapregions', (
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('bridge', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('ix', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('size', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('n', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('type', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_GapRegions'])
+
+        # Adding model 'hg19_CytoBand'
+        db.create_table(u'annotation_server_hg19_cytoband', (
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('gieStain', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_CytoBand'])
+
+        # Adding model 'ce10_GC'
+        db.create_table(u'annotation_server_ce10_gc', (
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_GC'])
+
+        # Adding model 'hg19_GC'
+        db.create_table(u'annotation_server_hg19_gc', (
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_GC'])
+
+        # Adding model 'ce10_MappabilityEmpirial'
+        db.create_table(u'annotation_server_ce10_mappabilityempirial', (
+            ('blockStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('blockSizes', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('score', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('blockCount', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('itemRgb', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('thickEnd', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('thickStart', self.gf('django.db.models.fields.IntegerField')(null=True)),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_MappabilityEmpirial'])
+
+        # Adding model 'hg19_Conservation'
+        db.create_table(u'annotation_server_hg19_conservation', (
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_Conservation'])
+
+        # Adding model 'dm3_Conservation'
+        db.create_table(u'annotation_server_dm3_conservation', (
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_Conservation'])
+
+        # Adding model 'ce10_EnsGene'
+        db.create_table(u'annotation_server_ce10_ensgene', (
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('txEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonFrames', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('txStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonCount', self.gf('django.db.models.fields.IntegerField')()),
+            ('cdsEndStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('cdsEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name2', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('exonStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+            ('cdsStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('cdsStartStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('score', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('exonEnds', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_EnsGene'])
+
+        # Adding model 'ce10_CytoBand'
+        db.create_table(u'annotation_server_ce10_cytoband', (
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('gieStain', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_CytoBand'])
+
+        # Adding model 'dm3_CytoBand'
+        db.create_table(u'annotation_server_dm3_cytoband', (
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('gieStain', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_CytoBand'])
+
+        # Adding model 'dm3_Sequence'
+        db.create_table(u'annotation_server_dm3_sequence', (
+            ('seq_id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(default='+', max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True, db_index=True)),
+            ('seq', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_Sequence'])
+
+        # Adding model 'hg19_ChromInfo'
+        db.create_table(u'annotation_server_hg19_chrominfo', (
+            ('size', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('fileName', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_ChromInfo'])
+
+        # Adding model 'dm3_MappabilityEmpirial'
+        db.create_table(u'annotation_server_dm3_mappabilityempirial', (
+            ('blockStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('blockSizes', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('score', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('blockCount', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('itemRgb', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('thickEnd', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('thickStart', self.gf('django.db.models.fields.IntegerField')(null=True)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_MappabilityEmpirial'])
+
+        # Adding model 'ce10_Sequence'
+        db.create_table(u'annotation_server_ce10_sequence', (
+            ('seq_id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(default='+', max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True, db_index=True)),
+            ('seq', self.gf('django.db.models.fields.TextField')()),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_Sequence'])
+
+        # Adding model 'dm3_GC'
+        db.create_table(u'annotation_server_dm3_gc', (
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_GC'])
+
+        # Adding model 'dm3_EnsGene'
+        db.create_table(u'annotation_server_dm3_ensgene', (
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('txEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonFrames', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('txStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonCount', self.gf('django.db.models.fields.IntegerField')()),
+            ('cdsEndStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('cdsEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name2', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('exonStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+            ('cdsStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('cdsStartStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('score', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('exonEnds', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_EnsGene'])
+
+        # Adding model 'dm3_GapRegions'
+        db.create_table(u'annotation_server_dm3_gapregions', (
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('bridge', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('ix', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('size', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('n', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('type', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('annotation_server', ['dm3_GapRegions'])
+
+        # Adding model 'hg19_MappabilityTheoretical'
+        db.create_table(u'annotation_server_hg19_mappabilitytheoretical', (
+            ('blockStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('blockSizes', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('chromStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('score', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('chromEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('blockCount', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('itemRgb', self.gf('django.db.models.fields.CharField')(max_length=255)),
+            ('thickEnd', self.gf('django.db.models.fields.IntegerField')(null=True)),
+            ('thickStart', self.gf('django.db.models.fields.IntegerField')(null=True)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_MappabilityTheoretical'])
+
+        # Adding model 'ce10_ChromInfo'
+        db.create_table(u'annotation_server_ce10_chrominfo', (
+            ('size', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('fileName', self.gf('django.db.models.fields.CharField')(max_length=255)),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_ChromInfo'])
+
+        # Adding model 'hg19_EnsGene'
+        db.create_table(u'annotation_server_hg19_ensgene', (
+            ('bin', self.gf('django.db.models.fields.IntegerField')()),
+            ('txEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonFrames', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700)),
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('txStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('exonCount', self.gf('django.db.models.fields.IntegerField')()),
+            ('cdsEndStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('strand', self.gf('django.db.models.fields.CharField')(max_length=1)),
+            ('cdsEnd', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('name2', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('exonStarts', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+            ('cdsStart', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('cdsStartStat', self.gf('django.db.models.fields.CharField')(max_length=10, db_index=True)),
+            ('score', self.gf('django.db.models.fields.IntegerField')()),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('exonEnds', self.gf('django.db.models.fields.CommaSeparatedIntegerField')(max_length=3700, db_index=True)),
+        ))
+        db.send_create_signal('annotation_server', ['hg19_EnsGene'])
+
+        # Adding model 'ce10_Conservation'
+        db.create_table(u'annotation_server_ce10_conservation', (
+            ('annot', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.WigDescription'])),
+            ('value', self.gf('django.db.models.fields.FloatField')()),
+            ('position', self.gf('django.db.models.fields.IntegerField')(db_index=True)),
+            ('chrom', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('annotation_server', ['ce10_Conservation'])
+
+        # Deleting model 'EmpiricalMappability'
+        db.delete_table(u'annotation_server_empiricalmappability')
+
+        # Deleting model 'GCContent'
+        db.delete_table(u'annotation_server_gccontent')
+
+        # Deleting model 'Gene'
+        db.delete_table(u'annotation_server_gene')
+
+        # Deleting model 'GapRegionFile'
+        db.delete_table(u'annotation_server_gapregionfile')
+
+        # Deleting model 'ConservationTrack'
+        db.delete_table(u'annotation_server_conservationtrack')
+
+        # Deleting model 'ChromInfo'
+        db.delete_table(u'annotation_server_chrominfo')
+
+        # Deleting model 'TheoreticalMappability'
+        db.delete_table(u'annotation_server_theoreticalmappability')
+
+        # Deleting model 'CytoBand'
+        db.delete_table(u'annotation_server_cytoband')
+
+        # Deleting field 'dm3_FlyBase.genomebuild'
+        db.delete_column(u'annotation_server_dm3_flybase', 'genomebuild_id')
+
+        # Deleting field 'hg19_GenCode.genomebuild'
+        db.delete_column(u'annotation_server_hg19_gencode', 'genomebuild_id')
+
+        # Deleting field 'ce10_WormBase.genomebuild'
+        db.delete_column(u'annotation_server_ce10_wormbase', 'genomebuild_id')
+
+        # Adding field 'WigDescription.genome_build'
+        db.add_column(u'annotation_server_wigdescription', 'genome_build',
+                      self.gf('django.db.models.fields.CharField')(default=None, max_length=255),
+                      keep_default=False)
+
+        # Deleting field 'WigDescription.genomebuild'
+        db.delete_column(u'annotation_server_wigdescription', 'genomebuild_id')
+
+        # Adding field 'GenomeBuild.ucsc_equivalent'
+        db.add_column(u'annotation_server_genomebuild', 'ucsc_equivalent',
+                      self.gf('django.db.models.fields.related.ForeignKey')(to=orm['annotation_server.GenomeBuild'], null=True, blank=True),
+                      keep_default=False)
+
+
+    models = {
+        u'annotation_server.ce10_wormbase': {
+            'Meta': {'ordering': "['chrom', 'start']", 'object_name': 'ce10_WormBase'},
+            'attribute': ('django.db.models.fields.TextField', [], {}),
+            'cds': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'clone': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'end': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'feature': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'frame': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'gene': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'score': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'start': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'strand': ('django.db.models.fields.CharField', [], {'max_length': '1'})
+        },
+        u'annotation_server.chrominfo': {
+            'Meta': {'ordering': "['-size']", 'object_name': 'ChromInfo'},
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'fileName': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'size': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'annotation_server.conservationtrack': {
+            'Meta': {'ordering': "['chrom', 'position']", 'object_name': 'ConservationTrack'},
+            'annot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['annotation_server.WigDescription']"}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'value': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'annotation_server.cytoband': {
+            'Meta': {'ordering': "['chrom', 'chromStart']", 'object_name': 'CytoBand'},
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'chromEnd': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'chromStart': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            'gieStain': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        u'annotation_server.dm3_flybase': {
+            'Alias': ('django.db.models.fields.TextField', [], {}),
+            'Meta': {'ordering': "['chrom', 'start']", 'object_name': 'dm3_FlyBase'},
+            'attribute': ('django.db.models.fields.TextField', [], {}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'end': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'feature': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'frame': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'fullname': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'score': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'start': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'strand': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'symbol': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'annotation_server.empiricalmappability': {
+            'Meta': {'ordering': "['chrom', 'chromStart']", 'object_name': 'EmpiricalMappability'},
+            'blockCount': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'blockSizes': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700'}),
+            'blockStarts': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700'}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'chromEnd': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'chromStart': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'itemRgb': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'score': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'strand': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'thickEnd': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'thickStart': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        u'annotation_server.gapregionfile': {
+            'Meta': {'ordering': "['chrom', 'chromStart']", 'object_name': 'GapRegionFile'},
+            'bin': ('django.db.models.fields.IntegerField', [], {}),
+            'bridge': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'chromEnd': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'chromStart': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ix': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'n': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'size': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'annotation_server.gccontent': {
+            'Meta': {'ordering': "['chrom', 'position']", 'object_name': 'GCContent'},
+            'annot': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['annotation_server.WigDescription']"}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'position': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'value': ('django.db.models.fields.FloatField', [], {})
+        },
+        u'annotation_server.gene': {
+            'Meta': {'ordering': "['chrom', 'txStart']", 'object_name': 'Gene'},
+            'bin': ('django.db.models.fields.IntegerField', [], {}),
+            'cdsEnd': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'cdsEndStat': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'cdsStart': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'cdsStartStat': ('django.db.models.fields.CharField', [], {'max_length': '10', 'db_index': 'True'}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'exonCount': ('django.db.models.fields.IntegerField', [], {}),
+            'exonEnds': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700', 'db_index': 'True'}),
+            'exonFrames': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700'}),
+            'exonStarts': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700', 'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'name2': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'score': ('django.db.models.fields.IntegerField', [], {}),
+            'strand': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'txEnd': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'txStart': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'})
+        },
+        u'annotation_server.genomebuild': {
+            'Meta': {'object_name': 'GenomeBuild'},
+            'affiliation': ('django.db.models.fields.CharField', [], {'default': "'UCSC'", 'max_length': '255'}),
+            'available': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'default_build': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'html_path': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'source_name': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'}),
+            'species': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['annotation_server.Taxon']"})
+        },
+        u'annotation_server.hg19_gencode': {
+            'Meta': {'object_name': 'hg19_GenCode'},
+            'attribute': ('django.db.models.fields.TextField', [], {}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'end': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'feature': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'frame': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'gene_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'gene_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'gene_status': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'gene_type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'score': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'source': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'start': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'strand': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'transcript_id': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'transcript_name': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'transcript_status': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'}),
+            'transcript_type': ('django.db.models.fields.CharField', [], {'max_length': '100', 'db_index': 'True'})
+        },
+        u'annotation_server.taxon': {
+            'Meta': {'unique_together': "(('taxon_id', 'name'),)", 'object_name': 'Taxon'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'taxon_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'unique_name': ('django.db.models.fields.CharField', [], {'max_length': '1024', 'null': 'True', 'blank': 'True'})
+        },
+        u'annotation_server.theoreticalmappability': {
+            'Meta': {'ordering': "['chrom', 'chromStart']", 'object_name': 'TheoreticalMappability'},
+            'blockCount': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'blockSizes': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700'}),
+            'blockStarts': ('django.db.models.fields.CommaSeparatedIntegerField', [], {'max_length': '3700'}),
+            'chrom': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'chromEnd': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'chromStart': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'itemRgb': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'score': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'strand': ('django.db.models.fields.CharField', [], {'max_length': '1'}),
+            'thickEnd': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'thickStart': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        u'annotation_server.wigdescription': {
+            'Meta': {'object_name': 'WigDescription'},
+            'altColor': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'annotation_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'color': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'genomebuild': ('django.db.models.fields.related.ForeignKey', [], {'default': 'None', 'to': u"orm['annotation_server.GenomeBuild']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '1024'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {}),
+            'type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'visibility': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['annotation_server']

--- a/refinery/annotation_server/models.py
+++ b/refinery/annotation_server/models.py
@@ -31,7 +31,6 @@ class GenomeBuild(models.Model):
     source_name = models.CharField(max_length=1024, blank=True, null=True)
     available = models.BooleanField(default=True)
     default_build = models.BooleanField(default=False)
-    ucsc_equivalent = models.ForeignKey('GenomeBuild', blank=True, null=True)
 
     def __unicode__(self):
         return "%s: %s" % (self.name, self.description)

--- a/refinery/annotation_server/models.py
+++ b/refinery/annotation_server/models.py
@@ -105,26 +105,6 @@ def species_to_genome_build(species_name):
     return ret_list
 
 
-def resolve_to_ucsc_genome_build(alt_genome_build):
-    """returns the UCSC equivalent of a non-UCSC genome build name if an
-    equivalent exists
-    :param alt_genome_build: non-UCSC genome build name
-    :type alt_genome_build: string
-    :returns: string -- returns the UCSC equivalent genome build name
-    :raises: GenomeBuild.DoesNotExist
-    """
-    try:
-        genome_build = GenomeBuild.objects.exclude(affiliation='UCSC').get(
-            name__icontains=alt_genome_build)
-    except:
-        raise
-
-    try:
-        return genome_build.ucsc_equivalent.name
-    except:
-        raise GenomeBuild.DoesNotExist
-
-
 def genome_build_to_species(genome_build):
     """Returns the NCBI taxon ID of the species associated with the genome
     build provided


### PR DESCRIPTION
This PR helps to avoid a manual step:
`./manage.py migrate annotation_server 0001 --fake`

that needed to run upon an upgrade from a populated Django 1.6 instance to Django 1.7

This step needed to be taken due to the GenomeBuild model having a scircular dependency loop w/ a ForeignKey.

See: https://docs.djangoproject.com/en/1.7/topics/migrations/#upgrading-from-south