### PR TITLE
Scottx611x/django 1.7 upgrade storage fix

### DIFF
--- a/refinery/file_store/migrations/0001_initial.py
+++ b/refinery/file_store/migrations/0001_initial.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import models, migrations
 import django.utils.timezone
 import django_extensions.db.fields
@@ -27,7 +28,9 @@ class Migration(migrations.Migration):
             name='FileStoreItem',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('datafile', models.FileField(storage=file_store.models.SymlinkedFileSystemStorage(base_url='/media/file_store/', location='/vagrant/media/file_store'), max_length=1024, upload_to=file_store.models.file_path, blank=True)),
+                ('datafile', models.FileField(
+                    storage=file_store.models.SymlinkedFileSystemStorage(), max_length=1024,
+                    upload_to=file_store.models.file_path, blank=True)),
                 ('uuid', django_extensions.db.fields.UUIDField(unique=True, max_length=36, editable=False, blank=True)),
                 ('source', models.CharField(max_length=1024)),
                 ('sharename', models.CharField(max_length=20, blank=True)),

--- a/refinery/file_store/tests.py
+++ b/refinery/file_store/tests.py
@@ -16,7 +16,8 @@ from rest_framework.test import APITestCase
 from core.utils import get_full_url
 from .models import (file_path, get_temp_dir, get_file_object, FileStoreItem,
                      FileExtension, FILE_STORE_TEMP_DIR,
-                     generate_file_source_translator, FileType)
+                     generate_file_source_translator, FileType,
+                     SymlinkedFileSystemStorage)
 from .views import FileStoreItems
 from .serializers import FileStoreItemSerializer
 
@@ -444,3 +445,21 @@ class FileStoreItemsAPITests(APITestCase):
                                    % (self.url_root, self.invalid_format_uuid))
         response = self.view(request, self.invalid_format_uuid)
         self.assertEqual(response.status_code, 404)
+
+
+class SymlinkedFileSystemStorageTest(SimpleTestCase):
+    """SymlinkedFileSystemStorage test"""
+
+    def setUp(self):
+        self.symlinked_storage = SymlinkedFileSystemStorage()
+
+    def test_symlinked_storage(self):
+        self.assertIsNotNone(self.symlinked_storage)
+        self.assertEqual(
+            self.symlinked_storage.base_url,
+            urljoin(settings.MEDIA_URL, settings.FILE_STORE_DIR) + "/"
+        )
+        self.assertEqual(
+            self.symlinked_storage.location,
+            os.path.join(settings.MEDIA_ROOT, settings.FILE_STORE_DIR)
+        )


### PR DESCRIPTION
Fixes issue where SymlinkedFileSystemStorage's base_url and location fields were hardcoded into a migration file which caused issues due to there being different settings for our different enviornments (dev, prod, aws ...)